### PR TITLE
[DEV-10118] Fixes the exclusion path for magic number rules

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -62,7 +62,7 @@ Lint/MissingSuper:
 
 MagicNumbers/NoAssignment:
   Exclude:
-    - "/spec/**/*"
+    - "spec/**/*"
   Enabled: false
   AllowedAssignments:
     - instance_variables
@@ -71,7 +71,7 @@ MagicNumbers/NoAssignment:
 
 MagicNumbers/NoArgument:
   Exclude:
-    - "/spec/**/*"
+    - "spec/**/*"
   Enabled: true
   PermittedValues:
     - 0
@@ -79,7 +79,7 @@ MagicNumbers/NoArgument:
 
 MagicNumbers/NoDefault:
   Exclude:
-    - "/spec/**/*"
+    - "spec/**/*"
   Enabled: true
   PermittedValues:
     - 0
@@ -87,7 +87,7 @@ MagicNumbers/NoDefault:
 
 MagicNumbers/NoReturn:
   Exclude:
-    - "/spec/**/*"
+    - "spec/**/*"
   Enabled: true
   PermittedReturnValues:
     - 0

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.8'.freeze
+  VERSION = '0.2.9'.freeze
 end


### PR DESCRIPTION
[DEV-10118](https://give-lively.atlassian.net/browse/DEV-10118)

This PR builds on https://github.com/givelively/gl_rubocop/pull/9 but fixes the issue where the exclusion pattern applies to files within the `gl_rubocop` directory and not within the directory of the inheriting rubcop configuration (i.e. charity-api) 