### PR TITLE
[DEV-10118] Updates magic numbers exclusions to also exclude pack specs

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -850,18 +850,21 @@ MagicNumbers/Base: {}
 MagicNumbers/NoArgument:
   Exclude:
   - "/spec/**/*"
+  - "/**/spec/**/*"
   PermittedValues:
   - 0
   - 1
 MagicNumbers/NoDefault:
   Exclude:
   - "/spec/**/*"
+  - "/**/spec/**/*"
   PermittedValues:
   - 0
   - 1
 MagicNumbers/NoReturn:
   Exclude:
   - "/spec/**/*"
+  - "/**/spec/**/*"
   PermittedReturnValues:
   - 0
   - 1

--- a/README.md
+++ b/README.md
@@ -54,3 +54,31 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 8. Following the authorization prompts listed by the gem command.
 
 9. Your changes have now been published to the rubygems registry.
+
+## Testing Locally
+It's likely the case you'll want to test your changes locally before opening a PR, getting approval, and publishing the gem.
+
+To do so, complete the following steps:
+
+1. Save the changes to whichever files you have modified.
+
+2. Run the command `gem build` to create the bundle (this may require you to have bumped the version number)
+
+3. Go to the Gemfile in whichever ruby-based repo you want to test your rubocop changes against
+
+4. Create an entry for gl_rubocop specifiying the *relative* path to your local `gl_rubocop` repo (ex. `../code/gl_rubocop`):
+
+```ruby
+gem 'gl_rubocop', '~> 0.2.9', path: '../path/to/your/local/gl_rubocop'
+```
+
+5. Within the same repo as the Gemfile you just updated run `bundle install`
+
+6. Finally add the following lines to your rubocop configuration file
+
+```yml
+ inherit_gem:
+    gl_rubocop: default.yml
+```
+
+7. Now you can test your rubocop changes local with the target repo.

--- a/default.yml
+++ b/default.yml
@@ -63,6 +63,7 @@ Lint/MissingSuper:
 MagicNumbers/NoAssignment:
   Exclude:
     - "spec/**/*"
+    - "**/spec/**/*"
   Enabled: false
   AllowedAssignments:
     - instance_variables
@@ -72,6 +73,7 @@ MagicNumbers/NoAssignment:
 MagicNumbers/NoArgument:
   Exclude:
     - "spec/**/*"
+    - "**/spec/**/*"
   Enabled: true
   PermittedValues:
     - 0
@@ -80,6 +82,7 @@ MagicNumbers/NoArgument:
 MagicNumbers/NoDefault:
   Exclude:
     - "spec/**/*"
+    - "**/spec/**/*"
   Enabled: true
   PermittedValues:
     - 0
@@ -88,6 +91,7 @@ MagicNumbers/NoDefault:
 MagicNumbers/NoReturn:
   Exclude:
     - "spec/**/*"
+    - "**/spec/**/*"
   Enabled: true
   PermittedReturnValues:
     - 0

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.9'.freeze
+  VERSION = '0.2.10'.freeze
 end


### PR DESCRIPTION
[DEV-10118](https://give-lively.atlassian.net/browse/DEV-10118)

Another follow-up to https://github.com/givelively/gl_rubocop/pull/10 and https://github.com/givelively/gl_rubocop/pull/9. 

Until opening the resulting charity-api [PR](https://github.com/givelively/charity-api/pull/11328) I hadn't realized that packs have their own `spec` subfolders which were not covered by the exclusion patterns I had applied previously.

This PR ensures that when a repo has `spec` subdirectories, we also exclude them from being linted by the MagicNumber rules. 

