### PR TITLE
Add NoStubbingPerformAsync to rubocop yaml

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -67,6 +67,7 @@ GLCops/CallbackMethodNames: {}
 GLCops/InteractorInheritsFromInteractorBase:
   Include:
   - app/interactors/**/*
+GLCops/NoStubbingPerformAsync: {}
 GLCops/PreventErbFiles: {}
 GLCops/RailsCache: {}
 GLCops/SidekiqInheritsFromSidekiqJob:

--- a/default.yml
+++ b/default.yml
@@ -7,8 +7,8 @@ require:
   - rubocop-rake
   - ./lib/gl_rubocop/gl_cops/callback_method_names.rb
   - ./lib/gl_rubocop/gl_cops/interactor_inherits_from_interactor_base.rb
-  - ./lib/gl_rubocop/gl_cops/prevent_erb_files.rb
   - ./lib/gl_rubocop/gl_cops/no_stubbing_perform_async.rb
+  - ./lib/gl_rubocop/gl_cops/prevent_erb_files.rb
   - ./lib/gl_rubocop/gl_cops/rails_cache.rb
   - ./lib/gl_rubocop/gl_cops/sidekiq_inherits_from_sidekiq_job.rb
   - ./lib/gl_rubocop/gl_cops/unique_identifier.rb

--- a/default.yml
+++ b/default.yml
@@ -5,9 +5,10 @@ require:
   - rubocop-magic_numbers
   - rubocop-haml
   - rubocop-rake
-  - ./lib/gl_rubocop/gl_cops/interactor_inherits_from_interactor_base.rb
   - ./lib/gl_rubocop/gl_cops/callback_method_names.rb
+  - ./lib/gl_rubocop/gl_cops/interactor_inherits_from_interactor_base.rb
   - ./lib/gl_rubocop/gl_cops/prevent_erb_files.rb
+  - ./lib/gl_rubocop/gl_cops/no_stubbing_perform_async.rb
   - ./lib/gl_rubocop/gl_cops/rails_cache.rb
   - ./lib/gl_rubocop/gl_cops/sidekiq_inherits_from_sidekiq_job.rb
   - ./lib/gl_rubocop/gl_cops/unique_identifier.rb
@@ -40,6 +41,9 @@ GLCops/InteractorInheritsFromInteractorBase:
   Enabled: true
   Include:
     - "app/interactors/**/*"
+
+GLCops/NoStubbingPerformAsync:
+  Enabled: true
 
 GLCops/PreventErbFiles:
   Enabled: true

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.11'.freeze
+  VERSION = '0.2.12'.freeze
 end


### PR DESCRIPTION
Added the cop in #13 but didn't add it to `default.yml` 🤦 

This PR actually enables `GLCops/NoStubbingPerformAsync`