### PR TITLE
Add 100 to the allowed magic numbers

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -871,6 +871,7 @@ MagicNumbers/NoArgument:
   PermittedValues:
   - 0
   - 1
+  - 100
 MagicNumbers/NoDefault:
   Exclude:
   - "/spec/**/*"
@@ -878,6 +879,7 @@ MagicNumbers/NoDefault:
   PermittedValues:
   - 0
   - 1
+  - 100
 MagicNumbers/NoReturn:
   Exclude:
   - "/spec/**/*"
@@ -885,6 +887,7 @@ MagicNumbers/NoReturn:
   PermittedReturnValues:
   - 0
   - 1
+  - 100
 Metrics/AbcSize:
   VersionAdded: '0.27'
   VersionChanged: '1.5'

--- a/default.yml
+++ b/default.yml
@@ -81,6 +81,7 @@ MagicNumbers/NoArgument:
   PermittedValues:
     - 0
     - 1
+    - 100
 
 MagicNumbers/NoAssignment:
   AllowedAssignments:
@@ -100,6 +101,7 @@ MagicNumbers/NoDefault:
   PermittedValues:
     - 0
     - 1
+    - 100
 
 MagicNumbers/NoReturn:
   Enabled: true
@@ -109,6 +111,7 @@ MagicNumbers/NoReturn:
   PermittedReturnValues:
     - 0
     - 1
+    - 100
 
 Metrics/AbcSize:
   Exclude:

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.12'.freeze
+  VERSION = '0.2.13'.freeze
 end


### PR DESCRIPTION
There are many places where we transform cents to dollars. 100 isn't a magic number