### PR TITLE
[DEV-10827] ignore lines with just strings

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -351,7 +351,7 @@ Layout/LineLength:
   IgnoreCopDirectives: true
   AllowedPatterns:
   - "^ *#"
-  - !ruby/regexp /^\s*['"].*['"]\s*$/
+  - ^\s*['"].*['"]\s*$
   Exclude:
   - "/**/*.haml"
 Layout/MultilineArrayBraceLayout:

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -350,8 +350,8 @@ Layout/LineLength:
   - https
   IgnoreCopDirectives: true
   AllowedPatterns:
-  - !ruby/regexp /^\s*['"].*['"]\s*$/
   - "^ *#"
+  - !ruby/regexp /^\s*['"].*['"]\s*$/
   Exclude:
   - "/**/*.haml"
 Layout/MultilineArrayBraceLayout:

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -350,6 +350,7 @@ Layout/LineLength:
   - https
   IgnoreCopDirectives: true
   AllowedPatterns:
+  - !ruby/regexp /^\s*['"].*['"]\s*$/
   - "^ *#"
   Exclude:
   - "/**/*.haml"

--- a/default.yml
+++ b/default.yml
@@ -68,6 +68,7 @@ Layout/ClassStructure:
 Layout/LineLength:
   AllowedPatterns:
     - "^ *#" # Ignores full lines starting with any indentation and a comment (#)
+    - !ruby/regexp /^\s*['"].*['"]\s*$/ # ignores lies that are string literals
   Max: 100
 
 Lint/MissingSuper:

--- a/default.yml
+++ b/default.yml
@@ -68,7 +68,7 @@ Layout/ClassStructure:
 Layout/LineLength:
   AllowedPatterns:
     - "^ *#" # Ignores full lines starting with any indentation and a comment (#)
-    - "^\\s*['\"].*['\"]\\s*$" # ignores lies that are string literals
+    - "^\\s*['\"].*['\"]\\s*$" # ignores lines that are string literals
   Max: 100
 
 Lint/MissingSuper:

--- a/default.yml
+++ b/default.yml
@@ -68,7 +68,7 @@ Layout/ClassStructure:
 Layout/LineLength:
   AllowedPatterns:
     - "^ *#" # Ignores full lines starting with any indentation and a comment (#)
-    - !ruby/regexp /^\s*['"].*['"]\s*$/ # ignores lies that are string literals
+    - "^\\s*['\"].*['\"]\\s*$" # ignores lies that are string literals
   Max: 100
 
 Lint/MissingSuper:

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.13'.freeze
+  VERSION = '0.2.14'.freeze
 end

--- a/spec/layout_line_length_allowed_patterns_spec.rb
+++ b/spec/layout_line_length_allowed_patterns_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rubocop/rspec/support'
+require 'gl_rubocop/gl_cops/unique_identifier'
+
+RSpec.describe RuboCop::Cop::Layout::LineLength, :rubocop do
+  include RuboCop::RSpec::ExpectOffense
+
+  describe 'AllowedPatterns' do
+    subject(:cop) { RuboCop::Cop::Layout::LineLength.new(config) }
+
+    let(:config) do
+      RuboCop::Config.new(
+        'Layout/LineLength' => {
+          'Max' => 100,
+          'AllowedPatterns' => [
+            '^ *#',
+            '^\s*[\'\"].*[\'\"]\s*$'
+          ]
+        }
+      )
+    end
+
+    it 'does not register offense for long comment lines' do
+      expect_no_offenses(<<~RUBY)
+        #{'#' * 120}
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        #{'#'  +'a' * 120}
+      RUBY
+    end
+
+    it 'does not register offense for long string literal lines' do
+      expect_no_offenses(<<~RUBY)
+        "#{'a' * 120}"
+      RUBY
+      expect_no_offenses(<<~RUBY)
+        '#{'b' * 120}'
+      RUBY
+    end
+
+    it 'registers offense for other long lines' do
+      expect_offense(<<~RUBY)
+        x = "#{'c' * 101}"
+                                                                                                            ^^^^^^^ Line is too long. [107/100]
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/layout/line_length_allowed_patterns_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_allowed_patterns_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :rubocop do
   include RuboCop::RSpec::ExpectOffense
 
   describe 'AllowedPatterns' do
-    subject(:cop) { RuboCop::Cop::Layout::LineLength.new(config) }
+    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       RuboCop::Config.new(
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :rubocop do
       RUBY
 
       expect_no_offenses(<<~RUBY)
-        #{'#'  +'a' * 120}
+        ##{'a' * 120}
       RUBY
     end
 


### PR DESCRIPTION
Added a rubocop configuration to ignore long lines that are just strings.
Strings that are assigned are still flagged as too long.

I also added a spec to ensure the regular expressions work