### PR TITLE
[DEV-11305] Test rubocop for I18n

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -102,6 +102,8 @@ Gemspec/RubyVersionGlobalsUsage:
   VersionChanged: '1.40'
   Include:
   - "**/*.gemspec"
+I18n/RailsI18n/DecorateString: {}
+I18n/RailsI18n/DecorateStringFormattingUsingInterpolation: {}
 Layout/AccessModifierIndentation:
   VersionAdded: '0.49'
   EnforcedStyle: indent

--- a/default.yml
+++ b/default.yml
@@ -4,6 +4,7 @@ require:
   - rubocop-rspec
   - rubocop-magic_numbers
   - rubocop-haml
+  - rubocop-i18n
   - rubocop-rake
   - rubocop-sorbet
   - ./lib/gl_rubocop/gl_cops/callback_method_names.rb
@@ -65,6 +66,12 @@ GLCops/UniqueIdentifier:
   Enabled: true
   Include:
     - "app/components/**/*.haml"
+
+I18n/GetText:
+  Enabled: false
+
+I18n/RailsI18n:
+  Enabled: true
 
 Layout/ClassStructure:
   Enabled: true

--- a/gl_rubocop.gemspec
+++ b/gl_rubocop.gemspec
@@ -2,6 +2,7 @@
 
 require_relative 'lib/gl_rubocop/version'
 
+# rubocop:disable I18n/RailsI18n/DecorateString
 NON_GEM_FILES = ['Gemfile', 'Gemfile.lock', 'Guardfile', 'bin/lint'].freeze
 
 Gem::Specification.new do |spec|
@@ -37,3 +38,4 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end
+# rubocop:enable I18n/RailsI18n/DecorateString

--- a/gl_rubocop.gemspec
+++ b/gl_rubocop.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 1.62.1'
   spec.add_dependency 'rubocop-haml', '~> 0.2.4'
+  spec.add_dependency 'rubocop-i18n'
   spec.add_dependency 'rubocop-magic_numbers'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'

--- a/lib/gl_rubocop/gl_cops/callback_method_names.rb
+++ b/lib/gl_rubocop/gl_cops/callback_method_names.rb
@@ -1,3 +1,4 @@
+# rubocop:disable I18n/RailsI18n/DecorateString
 module GLRubocop
   module GLCops
     # This cop ensures that controller callbacks are named methods, not inline blocks.
@@ -21,3 +22,4 @@ module GLRubocop
     end
   end
 end
+# rubocop:enable I18n/RailsI18n/DecorateString

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.16'.freeze
+  VERSION = '0.2.17'.freeze
 end

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.15'.freeze
+  VERSION = '0.2.16'.freeze
 end


### PR DESCRIPTION
This is a proposed Pull Request. 

This introduces a rubocop to ensure I18n translations are used in the form of the rubocop-i18n.

This introduces 2 cops:
I18n/RailsI18n/DecorateString that looks for strings that are being displayed to the user without being in a translate function
I18n/RailsI18n/DecorateStringFormattingUsingInterpolation that looks for translations keys that use string interpolation

[DecorateString](https://github.com/rubocop/rubocop-i18n?tab=readme-ov-file#i18nrailsi18ndecoratestring) currently has 160 offenses in our app directory
`app/admin`: 12
`app/commands`: 1
`app/components`: 34
`app/controllers`: 60
`app/helpers`: 1
`app/interactors`: 6
`app/mailers`: 1
`app/models`: 5
`app/services`: 19
`app/views`: 21

[DecorateStringFormattingUsingInterpolation](https://github.com/rubocop/rubocop-i18n?tab=readme-ov-file#i18nrailsi18ndecoratestringformattingusinginterpolation) currently has only 6 offenses in our app directory all in `app/view`

