### PR TITLE
Update to Max: 6 for parameter lists

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # NOTE: when updating the ruby versions, consider re-writing the rubocop_rules.yml
         # and updating rules_version in spec/rubocop_rules_spec.rb
-        ruby-version: ['3.3', '3.2', '3.1']
+        ruby-version: ['3.4', '3.3', '3.3']
     env:
       RAILS_ENV: test
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # NOTE: when updating the ruby versions, consider re-writing the rubocop_rules.yml
         # and updating rules_version in spec/rubocop_rules_spec.rb
-        ruby-version: ['3.4', '3.3', '3.3']
+        ruby-version: ['3.4', '3.3', '3.2.8']
     env:
       RAILS_ENV: test
     steps:

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -968,7 +968,7 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   VersionAdded: '0.25'
   VersionChanged: '1.5'
-  Max: 5
+  Max: 6
   CountKeywordArgs: true
   MaxOptionalParameters: 3
   Exclude:

--- a/default.yml
+++ b/default.yml
@@ -162,6 +162,7 @@ Metrics/MethodLength:
   Max: 15
 
 Metrics/ParameterLists:
+  Max: 6
   Exclude:
     - "db/seeds/**/*"
 


### PR DESCRIPTION
With max 6 (instead of the default, max 5), we cover most of our existing parameter lists.

This also updates the ruby version matrix that github actions runs.