### PR TITLE
Additional fix for ParameterList

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -973,6 +973,7 @@ Metrics/ParameterLists:
   MaxOptionalParameters: 3
   Exclude:
   - "/db/seeds/**/*"
+  - "/app/components/**/*"
 Metrics/PerceivedComplexity:
   VersionAdded: '0.25'
   VersionChanged: '0.81'

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -68,7 +68,9 @@ GLCops/InteractorInheritsFromInteractorBase:
   Include:
   - app/interactors/**/*
 GLCops/LimitFlashOptions: {}
-GLCops/NoStubbingPerformAsync: {}
+GLCops/NoStubbingPerformAsync:
+  Include:
+  - "**/*spec.rb"
 GLCops/PreventErbFiles: {}
 GLCops/RailsCache: {}
 GLCops/SidekiqInheritsFromSidekiqJob:

--- a/default.yml
+++ b/default.yml
@@ -50,6 +50,8 @@ GLCops/LimitFlashOptions:
 
 GLCops/NoStubbingPerformAsync:
   Enabled: true
+  Include:
+    - "**/*spec.rb"
 
 GLCops/PreventErbFiles:
   Enabled: true

--- a/default.yml
+++ b/default.yml
@@ -165,6 +165,7 @@ Metrics/ParameterLists:
   Max: 6
   Exclude:
     - "db/seeds/**/*"
+    - "app/components/**/*"
 
 Metrics/PerceivedComplexity:
   Exclude:

--- a/lib/gl_rubocop/gl_cops/no_stubbing_perform_async.rb
+++ b/lib/gl_rubocop/gl_cops/no_stubbing_perform_async.rb
@@ -27,11 +27,11 @@ module GLRubocop
       PATTERN
 
       def on_send(node)
-        if have_received_perform?(node) || receive_perform?(node)
-          # Find the expect or allow context
-          offense_node = find_offense_node(node)
-          add_offense(offense_node) if offense_node
-        end
+        return unless have_received_perform?(node) || receive_perform?(node)
+
+        # Find the expect or allow context
+        offense_node = find_offense_node(node)
+        add_offense(offense_node) if offense_node
       end
 
       private
@@ -39,9 +39,8 @@ module GLRubocop
       def find_offense_node(node)
         current = node.parent
         while current
-          if rspec_stubbing?(current)
-            return current
-          end
+          return current if rspec_stubbing?(current)
+
           current = current.parent
         end
         nil
@@ -49,14 +48,13 @@ module GLRubocop
 
       def rspec_stubbing?(node)
         return false unless node.send_type?
-        return false unless [:to, :not_to, :to_not].include?(node.method_name)
+        return false unless %i[to not_to to_not].include?(node.method_name)
 
         receiver = node.receiver
-        return false unless receiver && receiver.send_type?
+        return false unless receiver&.send_type?
 
-        [:allow, :expect].include?(receiver.method_name)
+        %i[allow expect].include?(receiver.method_name)
       end
     end
   end
-
 end

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.18'.freeze
+  VERSION = '0.2.19'.freeze
 end

--- a/spec/gl_rubocop/gl_cops/no_stubbing_perform_async_spec.rb
+++ b/spec/gl_rubocop/gl_cops/no_stubbing_perform_async_spec.rb
@@ -40,7 +40,19 @@ RSpec.describe GLRubocop::GLCops::NoStubbingPerformAsync do
 
   it 'registers an offense when using allow perform_in' do
     source = <<~RUBY
-      allow(SomeWorker).to receive(:perform_in)
+      allow(SomeWorker).to receive(:perform_in).with(12)
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(1)
+    expect(report.offenses.first.message).to eq(expected_message)
+  end
+
+  it 'registers an offense when using expect and_return' do
+    source = <<~RUBY
+      expect(SomeWorker).to receive(:perform_async).and_return { 12 }
     RUBY
 
     processed_source = parse_source(source)


### PR DESCRIPTION
Follow up to #27, because the nested Rubocop config doesn't work with pronto (which is how we check linting on CI).

Also, fix the `NoStubbingPerformAsync` cop so that it catches when perform_async stubbing when it's called with additional methods