### PR TITLE
Add rubocop-erb, prevent haml instead of erb files

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -222,6 +222,8 @@ Layout/EmptyLines:
 Layout/EmptyLinesAroundAccessModifier:
   VersionAdded: '0.49'
   EnforcedStyle: around
+  References:
+  - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 Layout/EmptyLinesAroundArguments:
   VersionAdded: '0.52'
 Layout/EmptyLinesAroundAttributeAccessor:
@@ -323,6 +325,8 @@ Layout/HeredocIndentation:
 Layout/IndentationConsistency:
   VersionAdded: '0.49'
   EnforcedStyle: normal
+  References:
+  - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
   Exclude:
   - "/**/*.erb"
 Layout/IndentationStyle:
@@ -345,6 +349,8 @@ Layout/LeadingCommentSpace:
   VersionChanged: '0.73'
   AllowDoxygenCommentStyle: false
   AllowGemfileRubyComment: false
+  AllowRBSInlineAnnotation: false
+  AllowSteepAnnotation: false
 Layout/LeadingEmptyLines:
   VersionAdded: '0.57'
   VersionChanged: '0.77'
@@ -352,10 +358,11 @@ Layout/LeadingEmptyLines:
   - "/**/*.erb"
 Layout/LineLength:
   VersionAdded: '0.25'
-  VersionChanged: '1.4'
+  VersionChanged: '1.69'
   Max: 100
   AllowHeredoc: true
   AllowURI: true
+  AllowQualifiedName: true
   URISchemes:
   - http
   - https
@@ -363,6 +370,7 @@ Layout/LineLength:
   AllowedPatterns:
   - "^ *#"
   - ^\s*['"].*['"]\s*$
+  SplitStrings: false
   Exclude:
   - "/**/*.erb"
 Layout/MultilineArrayBraceLayout:
@@ -536,7 +544,7 @@ Lint/BigDecimalNew:
   VersionAdded: '0.53'
 Lint/BinaryOperatorWithIdenticalOperands:
   VersionAdded: '0.89'
-  VersionChanged: '1.7'
+  VersionChanged: '1.69'
 Lint/BooleanSymbol:
   VersionAdded: '0.50'
   VersionChanged: '1.22'
@@ -549,7 +557,7 @@ Lint/ConstantDefinitionInBlock:
   - enums
 Lint/Debugger:
   VersionAdded: '0.14'
-  VersionChanged: '1.46'
+  VersionChanged: '1.63'
   DebuggerMethods:
     Kernel:
     - binding.irb
@@ -560,8 +568,14 @@ Lint/Debugger:
     - Kernel.byebug
     - Kernel.remote_byebug
     Capybara:
+    - page.save_and_open_page
+    - page.save_and_open_screenshot
+    - page.save_page
+    - page.save_screenshot
     - save_and_open_page
     - save_and_open_screenshot
+    - save_page
+    - save_screenshot
     debug.rb:
     - binding.b
     - binding.break
@@ -583,6 +597,10 @@ Lint/Debugger:
     - jard
     WebConsole:
     - binding.console
+  DebuggerRequires:
+    debug.rb:
+    - debug/open
+    - debug/start
 Lint/DeprecatedClassMethods:
   VersionAdded: '0.19'
 Lint/DeprecatedOpenSSLConstant:
@@ -613,7 +631,7 @@ Lint/EmptyConditionalBody:
   AutoCorrect: contextual
   AllowComments: true
   VersionAdded: '0.89'
-  VersionChanged: '1.61'
+  VersionChanged: '1.73'
 Lint/EmptyEnsure:
   AutoCorrect: contextual
   VersionAdded: '0.10'
@@ -628,7 +646,7 @@ Lint/EmptyFile:
 Lint/EmptyInterpolation:
   AutoCorrect: contextual
   VersionAdded: '0.20'
-  VersionChanged: '1.61'
+  VersionChanged: '1.76'
 Lint/EmptyWhen:
   AllowComments: true
   VersionAdded: '0.45'
@@ -662,6 +680,7 @@ Lint/InterpolationCheck:
   VersionAdded: '0.50'
   VersionChanged: '1.40'
 Lint/LiteralAsCondition:
+  AutoCorrect: contextual
   VersionAdded: '0.51'
 Lint/LiteralInInterpolation:
   VersionAdded: '0.19'
@@ -722,9 +741,10 @@ Lint/RedundantCopEnableDirective:
   VersionAdded: '0.76'
 Lint/RedundantRequireStatement:
   VersionAdded: '0.76'
-  VersionChanged: '1.57'
+  VersionChanged: '1.73'
 Lint/RedundantSafeNavigation:
   VersionAdded: '0.93'
+  VersionChanged: '1.79'
   AllowedMethods:
   - instance_of?
   - kind_of?
@@ -734,6 +754,12 @@ Lint/RedundantSafeNavigation:
   - equal?
   - presence
   - present?
+  InferNonNilReceiver: false
+  AdditionalNilMethods:
+  - present?
+  - blank?
+  - try
+  - try!
 Lint/RedundantSplatExpansion:
   VersionAdded: '0.76'
   VersionChanged: '1.7'
@@ -785,6 +811,7 @@ Lint/ScriptPermission:
   VersionChanged: '0.50'
 Lint/SelfAssignment:
   VersionAdded: '0.89'
+  AllowRBSInlineAnnotation: false
 Lint/SendWithMixinArgument:
   VersionAdded: '0.75'
 Lint/ShadowedArgument:
@@ -792,8 +819,6 @@ Lint/ShadowedArgument:
   IgnoreImplicitReferences: false
 Lint/ShadowedException:
   VersionAdded: '0.41'
-Lint/ShadowingOuterLocalVariable:
-  VersionAdded: '0.9'
 Lint/StructNewOverride:
   VersionAdded: '0.81'
 Lint/SuppressedException:
@@ -836,10 +861,12 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   AutoCorrect: contextual
   VersionAdded: '0.21'
-  VersionChanged: '1.61'
+  VersionChanged: '1.69'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
   IgnoreNotImplementedMethods: true
+  NotImplementedExceptions:
+  - NotImplementedError
 Lint/UriEscapeUnescape:
   VersionAdded: '0.50'
 Lint/UriRegexp:
@@ -853,7 +880,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   AutoCorrect: contextual
   VersionAdded: '0.11'
-  VersionChanged: '1.61'
+  VersionChanged: '1.66'
   Exclude:
   - "/**/*.erb"
 Lint/UselessElseWithoutRescue:
@@ -900,6 +927,9 @@ MagicNumbers/NoReturn:
   - 0
   - 1
 Metrics/AbcSize:
+  References:
+  - https://wiki.c2.com/?AbcMetric
+  - https://en.wikipedia.org/wiki/ABC_Software_Metric
   VersionAdded: '0.27'
   VersionChanged: '1.5'
   AllowedMethods: []
@@ -935,8 +965,9 @@ Metrics/BlockLength:
     - Exclude
 Metrics/BlockNesting:
   VersionAdded: '0.25'
-  VersionChanged: '0.47'
+  VersionChanged: '1.65'
   CountBlocks: false
+  CountModifierForms: false
   Max: 3
   Exclude:
   - "/**/*.erb"
@@ -1021,6 +1052,7 @@ Naming/FileName:
   VersionAdded: '0.50'
   VersionChanged: '1.23'
   Exclude:
+  - "/Rakefile.rb"
   - "/**/*.erb"
   ExpectMatchingDefinition: false
   CheckDefinitionPathHierarchy: true
@@ -1090,8 +1122,13 @@ Naming/MemoizedInstanceVariableName:
   - optional
 Naming/MethodName:
   VersionAdded: '0.50'
+  VersionChanged: '1.75'
   EnforcedStyle: snake_case
   AllowedPatterns: []
+  ForbiddenIdentifiers:
+  - __id__
+  - __send__
+  ForbiddenPatterns: []
 Naming/MethodParameterName:
   VersionAdded: '0.53'
   VersionChanged: '0.77'
@@ -1114,22 +1151,25 @@ Naming/MethodParameterName:
   - pp
   - to
   ForbiddenNames: []
-Naming/PredicateName:
+Naming/PredicatePrefix:
   VersionAdded: '0.50'
-  VersionChanged: '0.77'
+  VersionChanged: '1.75'
   NamePrefix:
   - is_
   - has_
   - have_
+  - does_
   ForbiddenPrefixes:
   - is_
   - has_
   - have_
+  - does_
   AllowedMethods:
   - is_a?
   MethodDefinitionMacros:
   - define_method
   - define_singleton_method
+  UseSorbetSigs: false
   Exclude:
   - "/spec/**/*"
 Naming/RescuedExceptionsVariableName:
@@ -1138,10 +1178,12 @@ Naming/RescuedExceptionsVariableName:
   PreferredName: e
 Naming/VariableName:
   VersionAdded: '0.50'
-  VersionChanged: '1.8'
+  VersionChanged: '1.73'
   EnforcedStyle: snake_case
   AllowedIdentifiers: []
   AllowedPatterns: []
+  ForbiddenIdentifiers: []
+  ForbiddenPatterns: []
 Naming/VariableNumber:
   VersionAdded: '0.50'
   VersionChanged: '1.4'
@@ -1803,22 +1845,31 @@ Rake/MethodDefinitionInTask:
 Security/Eval:
   VersionAdded: '0.47'
 Security/JSONLoad:
+  References:
+  - https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load
+  - https://bugs.ruby-lang.org/issues/19528
   VersionAdded: '0.43'
   VersionChanged: '1.22'
 Security/MarshalLoad:
+  References:
+  - https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations
   VersionAdded: '0.47'
 Security/Open:
   VersionAdded: '0.53'
   VersionChanged: '1.0'
 Security/YAMLLoad:
+  References:
+  - https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
   VersionAdded: '0.47'
 Sorbet/ConstantsFromStrings:
   VersionAdded: 0.2.0
 Style/AccessModifierDeclarations:
   VersionAdded: '0.57'
-  VersionChanged: '0.81'
+  VersionChanged: '1.70'
   EnforcedStyle: group
   AllowModifiersOnSymbols: true
+  AllowModifiersOnAttrs: true
+  AllowModifiersOnAliasMethod: true
 Style/AccessorGrouping:
   VersionAdded: '0.87'
   EnforcedStyle: grouped
@@ -1886,7 +1937,18 @@ Style/CharacterLiteral:
   VersionAdded: '0.9'
 Style/ClassAndModuleChildren:
   VersionAdded: '0.19'
+  VersionChanged: '1.74'
   EnforcedStyle: nested
+  EnforcedStyleForClasses:
+  SupportedStylesForClasses:
+  -
+  - nested
+  - compact
+  EnforcedStyleForModules:
+  SupportedStylesForModules:
+  -
+  - nested
+  - compact
   Exclude:
   - "/app/controllers/smart_donations_legacy/**/*"
 Style/ClassCheck:
@@ -1991,6 +2053,8 @@ Style/ExponentialNotation:
   VersionAdded: '0.82'
   EnforcedStyle: scientific
 Style/FloatDivision:
+  References:
+  - https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html
   VersionAdded: '0.72'
   VersionChanged: '1.9'
   EnforcedStyle: single_coerce
@@ -2005,14 +2069,17 @@ Style/FormatString:
 Style/FormatStringToken:
   EnforcedStyle: annotated
   MaxUnannotatedPlaceholdersAllowed: 1
+  Mode: aggressive
   VersionAdded: '0.49'
-  VersionChanged: '1.0'
+  VersionChanged: '1.74'
   AllowedMethods:
   - redirect
   AllowedPatterns: []
 Style/GlobalStdStream:
   VersionAdded: '0.89'
 Style/GlobalVars:
+  References:
+  - https://www.zenspider.com/ruby/quickref.html
   VersionAdded: '0.13'
   AllowedVariables: []
   Exclude:
@@ -2032,14 +2099,15 @@ Style/HashLikeCase:
   MinBranchesCount: 3
 Style/HashSyntax:
   VersionAdded: '0.9'
-  VersionChanged: '1.24'
+  VersionChanged: '1.67'
   EnforcedStyle: ruby19
-  EnforcedShorthandSyntax: always
+  EnforcedShorthandSyntax: either
   SupportedShorthandSyntax:
   - always
   - never
   - either
   - consistent
+  - either_consistent
   UseHashRocketsWithSymbolValues: false
   PreferHashRocketsForNonAlnumEndingSymbols: false
 Style/HashTransformKeys:
@@ -2091,8 +2159,9 @@ Style/Lambda:
   VersionChanged: '0.40'
   EnforcedStyle: line_count_dependent
 Style/LambdaCall:
+  AutoCorrect: contextual
   VersionAdded: '0.13'
-  VersionChanged: '0.14'
+  VersionChanged: "<<next>>"
   EnforcedStyle: call
 Style/LineEndConcatenation:
   VersionAdded: '0.18'
@@ -2185,9 +2254,10 @@ Style/NestedTernaryOperator:
   - "/**/*.erb"
 Style/Next:
   VersionAdded: '0.22'
-  VersionChanged: '0.35'
+  VersionChanged: '1.75'
   EnforcedStyle: skip_modifier_ifs
   MinBodyLength: 3
+  AllowConsecutiveConditionals: false
   Exclude:
   - "/**/*.erb"
 Style/NilComparison:
@@ -2282,12 +2352,17 @@ Style/RedundantCapitalW:
   VersionAdded: '0.76'
 Style/RedundantCondition:
   VersionAdded: '0.76'
+  VersionChanged: '1.73'
+  AllowedMethods:
+  - nonzero?
 Style/RedundantConditional:
   VersionAdded: '0.50'
 Style/RedundantException:
   VersionAdded: '0.14'
   VersionChanged: '0.29'
 Style/RedundantFetchBlock:
+  References:
+  - https://github.com/fastruby/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code
   SafeForConstants: false
   VersionAdded: '0.86'
 Style/RedundantFileExtensionInRequire:
@@ -2335,7 +2410,7 @@ Style/RescueStandardError:
   EnforcedStyle: explicit
 Style/SafeNavigation:
   VersionAdded: '0.43'
-  VersionChanged: '1.27'
+  VersionChanged: '1.67'
   ConvertCodeThatCanStartToReturnNil: false
   AllowedMethods:
   - present?
@@ -2345,6 +2420,8 @@ Style/SafeNavigation:
   - try!
   MaxChainLength: 2
 Style/Sample:
+  References:
+  - https://github.com/fastruby/fast-ruby#arrayshufflefirst-vs-arraysample-code
   VersionAdded: '0.30'
 Style/SelfAssignment:
   VersionAdded: '0.19'
@@ -2407,7 +2484,7 @@ Style/SymbolLiteral:
   VersionAdded: '0.30'
 Style/SymbolProc:
   VersionAdded: '0.26'
-  VersionChanged: '1.40'
+  VersionChanged: '1.64'
   AllowMethodsWithArguments: false
   AllowedMethods:
   - define_method
@@ -2432,6 +2509,7 @@ Style/TrailingCommaInArguments:
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
+  - diff_comma
   - no_comma
   Exclude:
   - "/**/*.erb"
@@ -2441,6 +2519,7 @@ Style/TrailingCommaInArrayLiteral:
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
+  - diff_comma
   - no_comma
   Exclude:
   - "/**/*.erb"
@@ -2449,6 +2528,7 @@ Style/TrailingCommaInHashLiteral:
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
+  - diff_comma
   - no_comma
   VersionAdded: '0.53'
   Exclude:
@@ -2509,6 +2589,8 @@ Style/WordArray:
   MinSize: 2
   WordRegex: !ruby/regexp /\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/
 Style/YodaCondition:
+  References:
+  - https://en.wikipedia.org/wiki/Yoda_conditions
   EnforcedStyle: forbid_for_all_comparison_operators
   VersionAdded: '0.49'
   VersionChanged: '0.75'

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -222,8 +222,6 @@ Layout/EmptyLines:
 Layout/EmptyLinesAroundAccessModifier:
   VersionAdded: '0.49'
   EnforcedStyle: around
-  References:
-  - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 Layout/EmptyLinesAroundArguments:
   VersionAdded: '0.52'
 Layout/EmptyLinesAroundAttributeAccessor:
@@ -325,8 +323,6 @@ Layout/HeredocIndentation:
 Layout/IndentationConsistency:
   VersionAdded: '0.49'
   EnforcedStyle: normal
-  References:
-  - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
   Exclude:
   - "/**/*.erb"
 Layout/IndentationStyle:
@@ -349,8 +345,6 @@ Layout/LeadingCommentSpace:
   VersionChanged: '0.73'
   AllowDoxygenCommentStyle: false
   AllowGemfileRubyComment: false
-  AllowRBSInlineAnnotation: false
-  AllowSteepAnnotation: false
 Layout/LeadingEmptyLines:
   VersionAdded: '0.57'
   VersionChanged: '0.77'
@@ -358,11 +352,10 @@ Layout/LeadingEmptyLines:
   - "/**/*.erb"
 Layout/LineLength:
   VersionAdded: '0.25'
-  VersionChanged: '1.69'
+  VersionChanged: '1.4'
   Max: 100
   AllowHeredoc: true
   AllowURI: true
-  AllowQualifiedName: true
   URISchemes:
   - http
   - https
@@ -370,7 +363,6 @@ Layout/LineLength:
   AllowedPatterns:
   - "^ *#"
   - ^\s*['"].*['"]\s*$
-  SplitStrings: false
   Exclude:
   - "/**/*.erb"
 Layout/MultilineArrayBraceLayout:
@@ -544,7 +536,7 @@ Lint/BigDecimalNew:
   VersionAdded: '0.53'
 Lint/BinaryOperatorWithIdenticalOperands:
   VersionAdded: '0.89'
-  VersionChanged: '1.69'
+  VersionChanged: '1.7'
 Lint/BooleanSymbol:
   VersionAdded: '0.50'
   VersionChanged: '1.22'
@@ -557,7 +549,7 @@ Lint/ConstantDefinitionInBlock:
   - enums
 Lint/Debugger:
   VersionAdded: '0.14'
-  VersionChanged: '1.63'
+  VersionChanged: '1.46'
   DebuggerMethods:
     Kernel:
     - binding.irb
@@ -568,14 +560,8 @@ Lint/Debugger:
     - Kernel.byebug
     - Kernel.remote_byebug
     Capybara:
-    - page.save_and_open_page
-    - page.save_and_open_screenshot
-    - page.save_page
-    - page.save_screenshot
     - save_and_open_page
     - save_and_open_screenshot
-    - save_page
-    - save_screenshot
     debug.rb:
     - binding.b
     - binding.break
@@ -597,10 +583,6 @@ Lint/Debugger:
     - jard
     WebConsole:
     - binding.console
-  DebuggerRequires:
-    debug.rb:
-    - debug/open
-    - debug/start
 Lint/DeprecatedClassMethods:
   VersionAdded: '0.19'
 Lint/DeprecatedOpenSSLConstant:
@@ -631,7 +613,7 @@ Lint/EmptyConditionalBody:
   AutoCorrect: contextual
   AllowComments: true
   VersionAdded: '0.89'
-  VersionChanged: '1.73'
+  VersionChanged: '1.61'
 Lint/EmptyEnsure:
   AutoCorrect: contextual
   VersionAdded: '0.10'
@@ -646,7 +628,7 @@ Lint/EmptyFile:
 Lint/EmptyInterpolation:
   AutoCorrect: contextual
   VersionAdded: '0.20'
-  VersionChanged: '1.76'
+  VersionChanged: '1.61'
 Lint/EmptyWhen:
   AllowComments: true
   VersionAdded: '0.45'
@@ -680,7 +662,6 @@ Lint/InterpolationCheck:
   VersionAdded: '0.50'
   VersionChanged: '1.40'
 Lint/LiteralAsCondition:
-  AutoCorrect: contextual
   VersionAdded: '0.51'
 Lint/LiteralInInterpolation:
   VersionAdded: '0.19'
@@ -741,10 +722,9 @@ Lint/RedundantCopEnableDirective:
   VersionAdded: '0.76'
 Lint/RedundantRequireStatement:
   VersionAdded: '0.76'
-  VersionChanged: '1.73'
+  VersionChanged: '1.57'
 Lint/RedundantSafeNavigation:
   VersionAdded: '0.93'
-  VersionChanged: '1.79'
   AllowedMethods:
   - instance_of?
   - kind_of?
@@ -754,12 +734,6 @@ Lint/RedundantSafeNavigation:
   - equal?
   - presence
   - present?
-  InferNonNilReceiver: false
-  AdditionalNilMethods:
-  - present?
-  - blank?
-  - try
-  - try!
 Lint/RedundantSplatExpansion:
   VersionAdded: '0.76'
   VersionChanged: '1.7'
@@ -811,7 +785,6 @@ Lint/ScriptPermission:
   VersionChanged: '0.50'
 Lint/SelfAssignment:
   VersionAdded: '0.89'
-  AllowRBSInlineAnnotation: false
 Lint/SendWithMixinArgument:
   VersionAdded: '0.75'
 Lint/ShadowedArgument:
@@ -819,6 +792,8 @@ Lint/ShadowedArgument:
   IgnoreImplicitReferences: false
 Lint/ShadowedException:
   VersionAdded: '0.41'
+Lint/ShadowingOuterLocalVariable:
+  VersionAdded: '0.9'
 Lint/StructNewOverride:
   VersionAdded: '0.81'
 Lint/SuppressedException:
@@ -861,12 +836,10 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   AutoCorrect: contextual
   VersionAdded: '0.21'
-  VersionChanged: '1.69'
+  VersionChanged: '1.61'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
   IgnoreNotImplementedMethods: true
-  NotImplementedExceptions:
-  - NotImplementedError
 Lint/UriEscapeUnescape:
   VersionAdded: '0.50'
 Lint/UriRegexp:
@@ -880,7 +853,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   AutoCorrect: contextual
   VersionAdded: '0.11'
-  VersionChanged: '1.66'
+  VersionChanged: '1.61'
   Exclude:
   - "/**/*.erb"
 Lint/UselessElseWithoutRescue:
@@ -927,9 +900,6 @@ MagicNumbers/NoReturn:
   - 0
   - 1
 Metrics/AbcSize:
-  References:
-  - https://wiki.c2.com/?AbcMetric
-  - https://en.wikipedia.org/wiki/ABC_Software_Metric
   VersionAdded: '0.27'
   VersionChanged: '1.5'
   AllowedMethods: []
@@ -965,9 +935,8 @@ Metrics/BlockLength:
     - Exclude
 Metrics/BlockNesting:
   VersionAdded: '0.25'
-  VersionChanged: '1.65'
+  VersionChanged: '0.47'
   CountBlocks: false
-  CountModifierForms: false
   Max: 3
   Exclude:
   - "/**/*.erb"
@@ -1052,7 +1021,6 @@ Naming/FileName:
   VersionAdded: '0.50'
   VersionChanged: '1.23'
   Exclude:
-  - "/Rakefile.rb"
   - "/**/*.erb"
   ExpectMatchingDefinition: false
   CheckDefinitionPathHierarchy: true
@@ -1122,13 +1090,8 @@ Naming/MemoizedInstanceVariableName:
   - optional
 Naming/MethodName:
   VersionAdded: '0.50'
-  VersionChanged: '1.75'
   EnforcedStyle: snake_case
   AllowedPatterns: []
-  ForbiddenIdentifiers:
-  - __id__
-  - __send__
-  ForbiddenPatterns: []
 Naming/MethodParameterName:
   VersionAdded: '0.53'
   VersionChanged: '0.77'
@@ -1151,25 +1114,22 @@ Naming/MethodParameterName:
   - pp
   - to
   ForbiddenNames: []
-Naming/PredicatePrefix:
+Naming/PredicateName:
   VersionAdded: '0.50'
-  VersionChanged: '1.75'
+  VersionChanged: '0.77'
   NamePrefix:
   - is_
   - has_
   - have_
-  - does_
   ForbiddenPrefixes:
   - is_
   - has_
   - have_
-  - does_
   AllowedMethods:
   - is_a?
   MethodDefinitionMacros:
   - define_method
   - define_singleton_method
-  UseSorbetSigs: false
   Exclude:
   - "/spec/**/*"
 Naming/RescuedExceptionsVariableName:
@@ -1178,12 +1138,10 @@ Naming/RescuedExceptionsVariableName:
   PreferredName: e
 Naming/VariableName:
   VersionAdded: '0.50'
-  VersionChanged: '1.73'
+  VersionChanged: '1.8'
   EnforcedStyle: snake_case
   AllowedIdentifiers: []
   AllowedPatterns: []
-  ForbiddenIdentifiers: []
-  ForbiddenPatterns: []
 Naming/VariableNumber:
   VersionAdded: '0.50'
   VersionChanged: '1.4'
@@ -1845,31 +1803,22 @@ Rake/MethodDefinitionInTask:
 Security/Eval:
   VersionAdded: '0.47'
 Security/JSONLoad:
-  References:
-  - https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load
-  - https://bugs.ruby-lang.org/issues/19528
   VersionAdded: '0.43'
   VersionChanged: '1.22'
 Security/MarshalLoad:
-  References:
-  - https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations
   VersionAdded: '0.47'
 Security/Open:
   VersionAdded: '0.53'
   VersionChanged: '1.0'
 Security/YAMLLoad:
-  References:
-  - https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
   VersionAdded: '0.47'
 Sorbet/ConstantsFromStrings:
   VersionAdded: 0.2.0
 Style/AccessModifierDeclarations:
   VersionAdded: '0.57'
-  VersionChanged: '1.70'
+  VersionChanged: '0.81'
   EnforcedStyle: group
   AllowModifiersOnSymbols: true
-  AllowModifiersOnAttrs: true
-  AllowModifiersOnAliasMethod: true
 Style/AccessorGrouping:
   VersionAdded: '0.87'
   EnforcedStyle: grouped
@@ -1937,18 +1886,7 @@ Style/CharacterLiteral:
   VersionAdded: '0.9'
 Style/ClassAndModuleChildren:
   VersionAdded: '0.19'
-  VersionChanged: '1.74'
   EnforcedStyle: nested
-  EnforcedStyleForClasses:
-  SupportedStylesForClasses:
-  -
-  - nested
-  - compact
-  EnforcedStyleForModules:
-  SupportedStylesForModules:
-  -
-  - nested
-  - compact
   Exclude:
   - "/app/controllers/smart_donations_legacy/**/*"
 Style/ClassCheck:
@@ -2053,8 +1991,6 @@ Style/ExponentialNotation:
   VersionAdded: '0.82'
   EnforcedStyle: scientific
 Style/FloatDivision:
-  References:
-  - https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html
   VersionAdded: '0.72'
   VersionChanged: '1.9'
   EnforcedStyle: single_coerce
@@ -2069,17 +2005,14 @@ Style/FormatString:
 Style/FormatStringToken:
   EnforcedStyle: annotated
   MaxUnannotatedPlaceholdersAllowed: 1
-  Mode: aggressive
   VersionAdded: '0.49'
-  VersionChanged: '1.74'
+  VersionChanged: '1.0'
   AllowedMethods:
   - redirect
   AllowedPatterns: []
 Style/GlobalStdStream:
   VersionAdded: '0.89'
 Style/GlobalVars:
-  References:
-  - https://www.zenspider.com/ruby/quickref.html
   VersionAdded: '0.13'
   AllowedVariables: []
   Exclude:
@@ -2099,15 +2032,14 @@ Style/HashLikeCase:
   MinBranchesCount: 3
 Style/HashSyntax:
   VersionAdded: '0.9'
-  VersionChanged: '1.67'
+  VersionChanged: '1.24'
   EnforcedStyle: ruby19
-  EnforcedShorthandSyntax: either
+  EnforcedShorthandSyntax: always
   SupportedShorthandSyntax:
   - always
   - never
   - either
   - consistent
-  - either_consistent
   UseHashRocketsWithSymbolValues: false
   PreferHashRocketsForNonAlnumEndingSymbols: false
 Style/HashTransformKeys:
@@ -2159,9 +2091,8 @@ Style/Lambda:
   VersionChanged: '0.40'
   EnforcedStyle: line_count_dependent
 Style/LambdaCall:
-  AutoCorrect: contextual
   VersionAdded: '0.13'
-  VersionChanged: "<<next>>"
+  VersionChanged: '0.14'
   EnforcedStyle: call
 Style/LineEndConcatenation:
   VersionAdded: '0.18'
@@ -2254,10 +2185,9 @@ Style/NestedTernaryOperator:
   - "/**/*.erb"
 Style/Next:
   VersionAdded: '0.22'
-  VersionChanged: '1.75'
+  VersionChanged: '0.35'
   EnforcedStyle: skip_modifier_ifs
   MinBodyLength: 3
-  AllowConsecutiveConditionals: false
   Exclude:
   - "/**/*.erb"
 Style/NilComparison:
@@ -2352,17 +2282,12 @@ Style/RedundantCapitalW:
   VersionAdded: '0.76'
 Style/RedundantCondition:
   VersionAdded: '0.76'
-  VersionChanged: '1.73'
-  AllowedMethods:
-  - nonzero?
 Style/RedundantConditional:
   VersionAdded: '0.50'
 Style/RedundantException:
   VersionAdded: '0.14'
   VersionChanged: '0.29'
 Style/RedundantFetchBlock:
-  References:
-  - https://github.com/fastruby/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code
   SafeForConstants: false
   VersionAdded: '0.86'
 Style/RedundantFileExtensionInRequire:
@@ -2410,7 +2335,7 @@ Style/RescueStandardError:
   EnforcedStyle: explicit
 Style/SafeNavigation:
   VersionAdded: '0.43'
-  VersionChanged: '1.67'
+  VersionChanged: '1.27'
   ConvertCodeThatCanStartToReturnNil: false
   AllowedMethods:
   - present?
@@ -2420,8 +2345,6 @@ Style/SafeNavigation:
   - try!
   MaxChainLength: 2
 Style/Sample:
-  References:
-  - https://github.com/fastruby/fast-ruby#arrayshufflefirst-vs-arraysample-code
   VersionAdded: '0.30'
 Style/SelfAssignment:
   VersionAdded: '0.19'
@@ -2484,7 +2407,7 @@ Style/SymbolLiteral:
   VersionAdded: '0.30'
 Style/SymbolProc:
   VersionAdded: '0.26'
-  VersionChanged: '1.64'
+  VersionChanged: '1.40'
   AllowMethodsWithArguments: false
   AllowedMethods:
   - define_method
@@ -2509,7 +2432,6 @@ Style/TrailingCommaInArguments:
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
-  - diff_comma
   - no_comma
   Exclude:
   - "/**/*.erb"
@@ -2519,7 +2441,6 @@ Style/TrailingCommaInArrayLiteral:
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
-  - diff_comma
   - no_comma
   Exclude:
   - "/**/*.erb"
@@ -2528,7 +2449,6 @@ Style/TrailingCommaInHashLiteral:
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
-  - diff_comma
   - no_comma
   VersionAdded: '0.53'
   Exclude:
@@ -2589,8 +2509,6 @@ Style/WordArray:
   MinSize: 2
   WordRegex: !ruby/regexp /\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/
 Style/YodaCondition:
-  References:
-  - https://en.wikipedia.org/wiki/Yoda_conditions
   EnforcedStyle: forbid_for_all_comparison_operators
   VersionAdded: '0.49'
   VersionChanged: '0.75'

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -117,6 +117,7 @@ Layout/ArgumentAlignment:
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/ArrayAlignment:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
@@ -124,6 +125,7 @@ Layout/ArrayAlignment:
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/AssignmentIndentation:
   VersionAdded: '0.49'
   VersionChanged: '1.45'
@@ -144,6 +146,7 @@ Layout/BlockAlignment:
   - start_of_line
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/BlockEndNewline:
   VersionAdded: '0.49'
 Layout/CaseIndentation:
@@ -174,6 +177,7 @@ Layout/ClosingParenthesisIndentation:
   VersionAdded: '0.49'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/CommentIndentation:
   AllowForAlignment: false
   VersionAdded: '0.49'
@@ -206,6 +210,7 @@ Layout/EmptyLineAfterGuardClause:
   VersionChanged: '0.59'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/EmptyLineAfterMagicComment:
   VersionAdded: '0.49'
 Layout/EmptyLineBetweenDefs:
@@ -259,6 +264,7 @@ Layout/EndAlignment:
   Severity: warning
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/EndOfLine:
   VersionAdded: '0.49'
   EnforcedStyle: native
@@ -274,6 +280,7 @@ Layout/FirstArgumentIndentation:
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/FirstArrayElementIndentation:
   VersionAdded: '0.68'
   VersionChanged: '0.77'
@@ -281,6 +288,7 @@ Layout/FirstArrayElementIndentation:
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/FirstHashElementIndentation:
   VersionAdded: '0.68'
   VersionChanged: '0.77'
@@ -288,6 +296,7 @@ Layout/FirstHashElementIndentation:
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/FirstParameterIndentation:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
@@ -295,6 +304,7 @@ Layout/FirstParameterIndentation:
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/HashAlignment:
   AllowMultipleStyles: true
   VersionAdded: '0.49'
@@ -317,6 +327,7 @@ Layout/HashAlignment:
   - ignore_explicit
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/HeredocIndentation:
   VersionAdded: '0.49'
   VersionChanged: '0.85'
@@ -325,6 +336,7 @@ Layout/IndentationConsistency:
   EnforcedStyle: normal
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/IndentationStyle:
   VersionAdded: '0.49'
   VersionChanged: '0.82'
@@ -336,6 +348,7 @@ Layout/IndentationWidth:
   AllowedPatterns: []
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/InitialIndentation:
   VersionAdded: '0.49'
   Exclude:
@@ -365,11 +378,13 @@ Layout/LineLength:
   - ^\s*['"].*['"]\s*$
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/MultilineArrayBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/MultilineBlockLayout:
   VersionAdded: '0.49'
 Layout/MultilineHashBraceLayout:
@@ -377,28 +392,33 @@ Layout/MultilineHashBraceLayout:
   EnforcedStyle: symmetrical
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/MultilineMethodCallBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/MultilineMethodCallIndentation:
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/MultilineMethodDefinitionBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/MultilineOperationIndentation:
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/ParameterAlignment:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
@@ -406,6 +426,7 @@ Layout/ParameterAlignment:
   IndentationWidth:
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/RescueEnsureAlignment:
   VersionAdded: '0.49'
 Layout/SpaceAfterColon:
@@ -511,12 +532,14 @@ Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Layout/TrailingWhitespace:
   VersionAdded: '0.49'
   VersionChanged: '1.0'
   AllowInHeredoc: false
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Lint/AmbiguousBlockAssociation:
   VersionAdded: '0.48'
   VersionChanged: '1.13'
@@ -625,6 +648,7 @@ Lint/EmptyFile:
   VersionAdded: '0.90'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Lint/EmptyInterpolation:
   AutoCorrect: contextual
   VersionAdded: '0.20'
@@ -805,6 +829,7 @@ Lint/Syntax:
   VersionAdded: '0.9'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Lint/ToJSON:
   VersionAdded: '0.66'
 Lint/TopLevelReturnWithArgument:
@@ -856,6 +881,7 @@ Lint/UselessAssignment:
   VersionChanged: '1.61'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Lint/UselessElseWithoutRescue:
   VersionAdded: '0.17'
   VersionChanged: '1.31'
@@ -877,6 +903,7 @@ Lint/Void:
   CheckForMethodsWithNoSideEffects: false
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 MagicNumbers/Base: {}
 MagicNumbers/NoArgument:
   Exclude:
@@ -925,6 +952,7 @@ Metrics/BlockLength:
   - "**/*_spec.rb"
   - "**/spec/**/*"
   - "/**/*.erb"
+  - "/**/*.haml"
   - "/app/admin/**/*"
   - "/db/**/*"
   - "/config/routes/*"
@@ -940,6 +968,7 @@ Metrics/BlockNesting:
   Max: 3
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Metrics/ClassLength:
   VersionAdded: '0.25'
   VersionChanged: '0.87'
@@ -1022,6 +1051,7 @@ Naming/FileName:
   VersionChanged: '1.23'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
   ExpectMatchingDefinition: false
   CheckDefinitionPathHierarchy: true
   CheckDefinitionPathHierarchyRoots:
@@ -2053,6 +2083,7 @@ Style/IdenticalConditionalBranches:
   VersionChanged: '1.19'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/IfInsideElse:
   AllowIfModifier: false
   VersionAdded: '0.36'
@@ -2062,6 +2093,7 @@ Style/IfUnlessModifier:
   VersionChanged: '0.30'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/IfUnlessModifierOfIfUnless:
   VersionAdded: '0.39'
   VersionChanged: '0.87'
@@ -2135,6 +2167,7 @@ Style/MultilineTernaryOperator:
   VersionChanged: '0.86'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/MultilineWhenThen:
   VersionAdded: '0.73'
 Style/MultipleComparison:
@@ -2183,6 +2216,7 @@ Style/NestedTernaryOperator:
   VersionChanged: '0.86'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/Next:
   VersionAdded: '0.22'
   VersionChanged: '0.35'
@@ -2190,6 +2224,7 @@ Style/Next:
   MinBodyLength: 3
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/NilComparison:
   VersionAdded: '0.12'
   VersionChanged: '0.59'
@@ -2239,6 +2274,7 @@ Style/ParallelAssignment:
   VersionAdded: '0.32'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/ParenthesesAroundCondition:
   VersionAdded: '0.9'
   VersionChanged: '0.56'
@@ -2330,6 +2366,7 @@ Style/RescueModifier:
   VersionChanged: '0.34'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/RescueStandardError:
   VersionAdded: '0.52'
   EnforcedStyle: explicit
@@ -2355,6 +2392,7 @@ Style/Semicolon:
   AllowAsExpressionSeparator: false
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/SignalException:
   VersionAdded: '0.11'
   VersionChanged: '0.37'
@@ -2435,6 +2473,7 @@ Style/TrailingCommaInArguments:
   - no_comma
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/TrailingCommaInArrayLiteral:
   VersionAdded: '0.53'
   EnforcedStyleForMultiline: no_comma
@@ -2444,6 +2483,7 @@ Style/TrailingCommaInArrayLiteral:
   - no_comma
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
@@ -2453,6 +2493,7 @@ Style/TrailingCommaInHashLiteral:
   VersionAdded: '0.53'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/TrailingMethodEndStatement:
   VersionAdded: '0.52'
 Style/TrailingUnderscoreVariable:
@@ -2497,11 +2538,13 @@ Style/WhileUntilDo:
   VersionAdded: '0.9'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/WhileUntilModifier:
   VersionAdded: '0.9'
   VersionChanged: '0.30'
   Exclude:
   - "/**/*.erb"
+  - "/**/*.haml"
 Style/WordArray:
   VersionAdded: '0.9'
   VersionChanged: '1.19'

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -115,15 +115,11 @@ Layout/ArgumentAlignment:
   VersionChanged: '0.77'
   EnforcedStyle: with_first_argument
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/ArrayAlignment:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: with_first_element
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/AssignmentIndentation:
   VersionAdded: '0.49'
   VersionChanged: '1.45'
@@ -142,8 +138,6 @@ Layout/BlockAlignment:
   - either
   - start_of_block
   - start_of_line
-  Exclude:
-  - "/**/*.haml"
 Layout/BlockEndNewline:
   VersionAdded: '0.49'
 Layout/CaseIndentation:
@@ -172,8 +166,6 @@ Layout/ClosingHeredocIndentation:
   VersionAdded: '0.57'
 Layout/ClosingParenthesisIndentation:
   VersionAdded: '0.49'
-  Exclude:
-  - "/**/*.haml"
 Layout/CommentIndentation:
   AllowForAlignment: false
   VersionAdded: '0.49'
@@ -202,8 +194,6 @@ Layout/EmptyComment:
 Layout/EmptyLineAfterGuardClause:
   VersionAdded: '0.56'
   VersionChanged: '0.59'
-  Exclude:
-  - "/**/*.haml"
 Layout/EmptyLineAfterMagicComment:
   VersionAdded: '0.49'
 Layout/EmptyLineBetweenDefs:
@@ -255,8 +245,6 @@ Layout/EndAlignment:
   - variable
   - start_of_line
   Severity: warning
-  Exclude:
-  - "/**/*.haml"
 Layout/EndOfLine:
   VersionAdded: '0.49'
   EnforcedStyle: native
@@ -270,29 +258,21 @@ Layout/FirstArgumentIndentation:
   VersionChanged: '0.77'
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/FirstArrayElementIndentation:
   VersionAdded: '0.68'
   VersionChanged: '0.77'
   EnforcedStyle: special_inside_parentheses
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/FirstHashElementIndentation:
   VersionAdded: '0.68'
   VersionChanged: '0.77'
   EnforcedStyle: special_inside_parentheses
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/FirstParameterIndentation:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: consistent
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/HashAlignment:
   AllowMultipleStyles: true
   VersionAdded: '0.49'
@@ -313,16 +293,12 @@ Layout/HashAlignment:
   - always_ignore
   - ignore_implicit
   - ignore_explicit
-  Exclude:
-  - "/**/*.haml"
 Layout/HeredocIndentation:
   VersionAdded: '0.49'
   VersionChanged: '0.85'
 Layout/IndentationConsistency:
   VersionAdded: '0.49'
   EnforcedStyle: normal
-  Exclude:
-  - "/**/*.haml"
 Layout/IndentationStyle:
   VersionAdded: '0.49'
   VersionChanged: '0.82'
@@ -332,8 +308,6 @@ Layout/IndentationWidth:
   VersionAdded: '0.49'
   Width: 2
   AllowedPatterns: []
-  Exclude:
-  - "/**/*.haml"
 Layout/InitialIndentation:
   VersionAdded: '0.49'
 Layout/LeadingCommentSpace:
@@ -357,49 +331,33 @@ Layout/LineLength:
   AllowedPatterns:
   - "^ *#"
   - ^\s*['"].*['"]\s*$
-  Exclude:
-  - "/**/*.haml"
 Layout/MultilineArrayBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
-  Exclude:
-  - "/**/*.haml"
 Layout/MultilineBlockLayout:
   VersionAdded: '0.49'
 Layout/MultilineHashBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
-  Exclude:
-  - "/**/*.haml"
 Layout/MultilineMethodCallBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
-  Exclude:
-  - "/**/*.haml"
 Layout/MultilineMethodCallIndentation:
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/MultilineMethodDefinitionBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
-  Exclude:
-  - "/**/*.haml"
 Layout/MultilineOperationIndentation:
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/ParameterAlignment:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: with_first_parameter
   IndentationWidth:
-  Exclude:
-  - "/**/*.haml"
 Layout/RescueEnsureAlignment:
   VersionAdded: '0.49'
 Layout/SpaceAfterColon:
@@ -503,14 +461,10 @@ Layout/TrailingEmptyLines:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: final_newline
-  Exclude:
-  - "/**/*.haml"
 Layout/TrailingWhitespace:
   VersionAdded: '0.49'
   VersionChanged: '1.0'
   AllowInHeredoc: false
-  Exclude:
-  - "/**/*.haml"
 Lint/AmbiguousBlockAssociation:
   VersionAdded: '0.48'
   VersionChanged: '1.13'
@@ -617,8 +571,6 @@ Lint/EmptyExpression:
 Lint/EmptyFile:
   AllowComments: true
   VersionAdded: '0.90'
-  Exclude:
-  - "/**/*.haml"
 Lint/EmptyInterpolation:
   AutoCorrect: contextual
   VersionAdded: '0.20'
@@ -795,8 +747,6 @@ Lint/SuppressedException:
   VersionChanged: '1.12'
 Lint/Syntax:
   VersionAdded: '0.9'
-  Exclude:
-  - "/**/*.haml"
 Lint/ToJSON:
   VersionAdded: '0.66'
 Lint/TopLevelReturnWithArgument:
@@ -846,8 +796,6 @@ Lint/UselessAssignment:
   AutoCorrect: contextual
   VersionAdded: '0.11'
   VersionChanged: '1.61'
-  Exclude:
-  - "/**/*.haml"
 Lint/UselessElseWithoutRescue:
   VersionAdded: '0.17'
   VersionChanged: '1.31'
@@ -867,8 +815,6 @@ Lint/Void:
   VersionAdded: '0.9'
   VersionChanged: '1.61'
   CheckForMethodsWithNoSideEffects: false
-  Exclude:
-  - "/**/*.haml"
 MagicNumbers/Base: {}
 MagicNumbers/NoArgument:
   Exclude:
@@ -916,7 +862,6 @@ Metrics/BlockLength:
   - "/**/*.gemspec"
   - "**/*_spec.rb"
   - "**/spec/**/*"
-  - "/**/*.haml"
   - "/app/admin/**/*"
   - "/db/**/*"
   - "/config/routes/*"
@@ -930,8 +875,6 @@ Metrics/BlockNesting:
   VersionChanged: '0.47'
   CountBlocks: false
   Max: 3
-  Exclude:
-  - "/**/*.haml"
 Metrics/ClassLength:
   VersionAdded: '0.25'
   VersionChanged: '0.87'
@@ -1012,8 +955,7 @@ Naming/ConstantName:
 Naming/FileName:
   VersionAdded: '0.50'
   VersionChanged: '1.23'
-  Exclude:
-  - "/**/*.haml"
+  Exclude: []
   ExpectMatchingDefinition: false
   CheckDefinitionPathHierarchy: true
   CheckDefinitionPathHierarchyRoots:
@@ -2043,8 +1985,6 @@ Style/HashTransformValues:
 Style/IdenticalConditionalBranches:
   VersionAdded: '0.36'
   VersionChanged: '1.19'
-  Exclude:
-  - "/**/*.haml"
 Style/IfInsideElse:
   AllowIfModifier: false
   VersionAdded: '0.36'
@@ -2052,8 +1992,6 @@ Style/IfInsideElse:
 Style/IfUnlessModifier:
   VersionAdded: '0.9'
   VersionChanged: '0.30'
-  Exclude:
-  - "/**/*.haml"
 Style/IfUnlessModifierOfIfUnless:
   VersionAdded: '0.39'
   VersionChanged: '0.87'
@@ -2125,8 +2063,6 @@ Style/MultilineMemoization:
 Style/MultilineTernaryOperator:
   VersionAdded: '0.9'
   VersionChanged: '0.86'
-  Exclude:
-  - "/**/*.haml"
 Style/MultilineWhenThen:
   VersionAdded: '0.73'
 Style/MultipleComparison:
@@ -2173,15 +2109,11 @@ Style/NestedParenthesizedCalls:
 Style/NestedTernaryOperator:
   VersionAdded: '0.9'
   VersionChanged: '0.86'
-  Exclude:
-  - "/**/*.haml"
 Style/Next:
   VersionAdded: '0.22'
   VersionChanged: '0.35'
   EnforcedStyle: skip_modifier_ifs
   MinBodyLength: 3
-  Exclude:
-  - "/**/*.haml"
 Style/NilComparison:
   VersionAdded: '0.12'
   VersionChanged: '0.59'
@@ -2229,8 +2161,6 @@ Style/OrAssignment:
   VersionAdded: '0.50'
 Style/ParallelAssignment:
   VersionAdded: '0.32'
-  Exclude:
-  - "/**/*.haml"
 Style/ParenthesesAroundCondition:
   VersionAdded: '0.9'
   VersionChanged: '0.56'
@@ -2320,8 +2250,6 @@ Style/RegexpLiteral:
 Style/RescueModifier:
   VersionAdded: '0.9'
   VersionChanged: '0.34'
-  Exclude:
-  - "/**/*.haml"
 Style/RescueStandardError:
   VersionAdded: '0.52'
   EnforcedStyle: explicit
@@ -2345,8 +2273,6 @@ Style/Semicolon:
   VersionAdded: '0.9'
   VersionChanged: '0.19'
   AllowAsExpressionSeparator: false
-  Exclude:
-  - "/**/*.haml"
 Style/SignalException:
   VersionAdded: '0.11'
   VersionChanged: '0.37'
@@ -2425,8 +2351,6 @@ Style/TrailingCommaInArguments:
   - comma
   - consistent_comma
   - no_comma
-  Exclude:
-  - "/**/*.haml"
 Style/TrailingCommaInArrayLiteral:
   VersionAdded: '0.53'
   EnforcedStyleForMultiline: no_comma
@@ -2434,8 +2358,6 @@ Style/TrailingCommaInArrayLiteral:
   - comma
   - consistent_comma
   - no_comma
-  Exclude:
-  - "/**/*.haml"
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
@@ -2443,8 +2365,6 @@ Style/TrailingCommaInHashLiteral:
   - consistent_comma
   - no_comma
   VersionAdded: '0.53'
-  Exclude:
-  - "/**/*.haml"
 Style/TrailingMethodEndStatement:
   VersionAdded: '0.52'
 Style/TrailingUnderscoreVariable:
@@ -2487,13 +2407,9 @@ Style/WhenThen:
   VersionAdded: '0.9'
 Style/WhileUntilDo:
   VersionAdded: '0.9'
-  Exclude:
-  - "/**/*.haml"
 Style/WhileUntilModifier:
   VersionAdded: '0.9'
   VersionChanged: '0.30'
-  Exclude:
-  - "/**/*.haml"
 Style/WordArray:
   VersionAdded: '0.9'
   VersionChanged: '1.19'

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -71,7 +71,7 @@ GLCops/LimitFlashOptions: {}
 GLCops/NoStubbingPerformAsync:
   Include:
   - "**/*spec.rb"
-GLCops/PreventErbFiles: {}
+GLCops/PreventHamlFiles: {}
 GLCops/RailsCache: {}
 GLCops/SidekiqInheritsFromSidekiqJob:
   Include:

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -79,7 +79,7 @@ GLCops/SidekiqInheritsFromSidekiqJob:
   - app/**/*_job.rb
 GLCops/UniqueIdentifier:
   Include:
-  - app/components/**/*.haml
+  - app/components/**/*.erb
 Gemspec/DuplicatedAssignment:
   Severity: warning
   VersionAdded: '0.52'
@@ -115,11 +115,15 @@ Layout/ArgumentAlignment:
   VersionChanged: '0.77'
   EnforcedStyle: with_first_argument
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/ArrayAlignment:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: with_first_element
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/AssignmentIndentation:
   VersionAdded: '0.49'
   VersionChanged: '1.45'
@@ -138,6 +142,8 @@ Layout/BlockAlignment:
   - either
   - start_of_block
   - start_of_line
+  Exclude:
+  - "/**/*.erb"
 Layout/BlockEndNewline:
   VersionAdded: '0.49'
 Layout/CaseIndentation:
@@ -166,10 +172,14 @@ Layout/ClosingHeredocIndentation:
   VersionAdded: '0.57'
 Layout/ClosingParenthesisIndentation:
   VersionAdded: '0.49'
+  Exclude:
+  - "/**/*.erb"
 Layout/CommentIndentation:
   AllowForAlignment: false
   VersionAdded: '0.49'
   VersionChanged: '1.24'
+  Exclude:
+  - "/**/*.erb"
 Layout/ConditionPosition:
   VersionAdded: '0.53'
   VersionChanged: '0.83'
@@ -194,6 +204,8 @@ Layout/EmptyComment:
 Layout/EmptyLineAfterGuardClause:
   VersionAdded: '0.56'
   VersionChanged: '0.59'
+  Exclude:
+  - "/**/*.erb"
 Layout/EmptyLineAfterMagicComment:
   VersionAdded: '0.49'
 Layout/EmptyLineBetweenDefs:
@@ -245,6 +257,8 @@ Layout/EndAlignment:
   - variable
   - start_of_line
   Severity: warning
+  Exclude:
+  - "/**/*.erb"
 Layout/EndOfLine:
   VersionAdded: '0.49'
   EnforcedStyle: native
@@ -258,21 +272,29 @@ Layout/FirstArgumentIndentation:
   VersionChanged: '0.77'
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/FirstArrayElementIndentation:
   VersionAdded: '0.68'
   VersionChanged: '0.77'
   EnforcedStyle: special_inside_parentheses
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/FirstHashElementIndentation:
   VersionAdded: '0.68'
   VersionChanged: '0.77'
   EnforcedStyle: special_inside_parentheses
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/FirstParameterIndentation:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: consistent
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/HashAlignment:
   AllowMultipleStyles: true
   VersionAdded: '0.49'
@@ -293,12 +315,16 @@ Layout/HashAlignment:
   - always_ignore
   - ignore_implicit
   - ignore_explicit
+  Exclude:
+  - "/**/*.erb"
 Layout/HeredocIndentation:
   VersionAdded: '0.49'
   VersionChanged: '0.85'
 Layout/IndentationConsistency:
   VersionAdded: '0.49'
   EnforcedStyle: normal
+  Exclude:
+  - "/**/*.erb"
 Layout/IndentationStyle:
   VersionAdded: '0.49'
   VersionChanged: '0.82'
@@ -308,8 +334,12 @@ Layout/IndentationWidth:
   VersionAdded: '0.49'
   Width: 2
   AllowedPatterns: []
+  Exclude:
+  - "/**/*.erb"
 Layout/InitialIndentation:
   VersionAdded: '0.49'
+  Exclude:
+  - "/**/*.erb"
 Layout/LeadingCommentSpace:
   VersionAdded: '0.49'
   VersionChanged: '0.73'
@@ -318,6 +348,8 @@ Layout/LeadingCommentSpace:
 Layout/LeadingEmptyLines:
   VersionAdded: '0.57'
   VersionChanged: '0.77'
+  Exclude:
+  - "/**/*.erb"
 Layout/LineLength:
   VersionAdded: '0.25'
   VersionChanged: '1.4'
@@ -331,33 +363,49 @@ Layout/LineLength:
   AllowedPatterns:
   - "^ *#"
   - ^\s*['"].*['"]\s*$
+  Exclude:
+  - "/**/*.erb"
 Layout/MultilineArrayBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
+  Exclude:
+  - "/**/*.erb"
 Layout/MultilineBlockLayout:
   VersionAdded: '0.49'
 Layout/MultilineHashBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
+  Exclude:
+  - "/**/*.erb"
 Layout/MultilineMethodCallBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
+  Exclude:
+  - "/**/*.erb"
 Layout/MultilineMethodCallIndentation:
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/MultilineMethodDefinitionBraceLayout:
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
+  Exclude:
+  - "/**/*.erb"
 Layout/MultilineOperationIndentation:
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/ParameterAlignment:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: with_first_parameter
   IndentationWidth:
+  Exclude:
+  - "/**/*.erb"
 Layout/RescueEnsureAlignment:
   VersionAdded: '0.49'
 Layout/SpaceAfterColon:
@@ -461,10 +509,14 @@ Layout/TrailingEmptyLines:
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: final_newline
+  Exclude:
+  - "/**/*.erb"
 Layout/TrailingWhitespace:
   VersionAdded: '0.49'
   VersionChanged: '1.0'
   AllowInHeredoc: false
+  Exclude:
+  - "/**/*.erb"
 Lint/AmbiguousBlockAssociation:
   VersionAdded: '0.48'
   VersionChanged: '1.13'
@@ -571,6 +623,8 @@ Lint/EmptyExpression:
 Lint/EmptyFile:
   AllowComments: true
   VersionAdded: '0.90'
+  Exclude:
+  - "/**/*.erb"
 Lint/EmptyInterpolation:
   AutoCorrect: contextual
   VersionAdded: '0.20'
@@ -646,6 +700,8 @@ Lint/OrderedMagicComments:
   VersionChanged: '1.37'
 Lint/OutOfRangeRegexpRef:
   VersionAdded: '0.89'
+  Exclude:
+  - "/**/*.erb"
 Lint/ParenthesesAsGroupedExpression:
   VersionAdded: '0.12'
   VersionChanged: '0.83'
@@ -747,6 +803,8 @@ Lint/SuppressedException:
   VersionChanged: '1.12'
 Lint/Syntax:
   VersionAdded: '0.9'
+  Exclude:
+  - "/**/*.erb"
 Lint/ToJSON:
   VersionAdded: '0.66'
 Lint/TopLevelReturnWithArgument:
@@ -796,6 +854,8 @@ Lint/UselessAssignment:
   AutoCorrect: contextual
   VersionAdded: '0.11'
   VersionChanged: '1.61'
+  Exclude:
+  - "/**/*.erb"
 Lint/UselessElseWithoutRescue:
   VersionAdded: '0.17'
   VersionChanged: '1.31'
@@ -815,6 +875,8 @@ Lint/Void:
   VersionAdded: '0.9'
   VersionChanged: '1.61'
   CheckForMethodsWithNoSideEffects: false
+  Exclude:
+  - "/**/*.erb"
 MagicNumbers/Base: {}
 MagicNumbers/NoArgument:
   Exclude:
@@ -862,6 +924,7 @@ Metrics/BlockLength:
   - "/**/*.gemspec"
   - "**/*_spec.rb"
   - "**/spec/**/*"
+  - "/**/*.erb"
   - "/app/admin/**/*"
   - "/db/**/*"
   - "/config/routes/*"
@@ -875,6 +938,8 @@ Metrics/BlockNesting:
   VersionChanged: '0.47'
   CountBlocks: false
   Max: 3
+  Exclude:
+  - "/**/*.erb"
 Metrics/ClassLength:
   VersionAdded: '0.25'
   VersionChanged: '0.87'
@@ -955,7 +1020,8 @@ Naming/ConstantName:
 Naming/FileName:
   VersionAdded: '0.50'
   VersionChanged: '1.23'
-  Exclude: []
+  Exclude:
+  - "/**/*.erb"
   ExpectMatchingDefinition: false
   CheckDefinitionPathHierarchy: true
   CheckDefinitionPathHierarchyRoots:
@@ -1985,6 +2051,8 @@ Style/HashTransformValues:
 Style/IdenticalConditionalBranches:
   VersionAdded: '0.36'
   VersionChanged: '1.19'
+  Exclude:
+  - "/**/*.erb"
 Style/IfInsideElse:
   AllowIfModifier: false
   VersionAdded: '0.36'
@@ -1992,6 +2060,8 @@ Style/IfInsideElse:
 Style/IfUnlessModifier:
   VersionAdded: '0.9'
   VersionChanged: '0.30'
+  Exclude:
+  - "/**/*.erb"
 Style/IfUnlessModifierOfIfUnless:
   VersionAdded: '0.39'
   VersionChanged: '0.87'
@@ -2063,6 +2133,8 @@ Style/MultilineMemoization:
 Style/MultilineTernaryOperator:
   VersionAdded: '0.9'
   VersionChanged: '0.86'
+  Exclude:
+  - "/**/*.erb"
 Style/MultilineWhenThen:
   VersionAdded: '0.73'
 Style/MultipleComparison:
@@ -2109,11 +2181,15 @@ Style/NestedParenthesizedCalls:
 Style/NestedTernaryOperator:
   VersionAdded: '0.9'
   VersionChanged: '0.86'
+  Exclude:
+  - "/**/*.erb"
 Style/Next:
   VersionAdded: '0.22'
   VersionChanged: '0.35'
   EnforcedStyle: skip_modifier_ifs
   MinBodyLength: 3
+  Exclude:
+  - "/**/*.erb"
 Style/NilComparison:
   VersionAdded: '0.12'
   VersionChanged: '0.59'
@@ -2161,6 +2237,8 @@ Style/OrAssignment:
   VersionAdded: '0.50'
 Style/ParallelAssignment:
   VersionAdded: '0.32'
+  Exclude:
+  - "/**/*.erb"
 Style/ParenthesesAroundCondition:
   VersionAdded: '0.9'
   VersionChanged: '0.56'
@@ -2250,6 +2328,8 @@ Style/RegexpLiteral:
 Style/RescueModifier:
   VersionAdded: '0.9'
   VersionChanged: '0.34'
+  Exclude:
+  - "/**/*.erb"
 Style/RescueStandardError:
   VersionAdded: '0.52'
   EnforcedStyle: explicit
@@ -2273,6 +2353,8 @@ Style/Semicolon:
   VersionAdded: '0.9'
   VersionChanged: '0.19'
   AllowAsExpressionSeparator: false
+  Exclude:
+  - "/**/*.erb"
 Style/SignalException:
   VersionAdded: '0.11'
   VersionChanged: '0.37'
@@ -2351,6 +2433,8 @@ Style/TrailingCommaInArguments:
   - comma
   - consistent_comma
   - no_comma
+  Exclude:
+  - "/**/*.erb"
 Style/TrailingCommaInArrayLiteral:
   VersionAdded: '0.53'
   EnforcedStyleForMultiline: no_comma
@@ -2358,6 +2442,8 @@ Style/TrailingCommaInArrayLiteral:
   - comma
   - consistent_comma
   - no_comma
+  Exclude:
+  - "/**/*.erb"
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
@@ -2365,6 +2451,8 @@ Style/TrailingCommaInHashLiteral:
   - consistent_comma
   - no_comma
   VersionAdded: '0.53'
+  Exclude:
+  - "/**/*.erb"
 Style/TrailingMethodEndStatement:
   VersionAdded: '0.52'
 Style/TrailingUnderscoreVariable:
@@ -2407,9 +2495,13 @@ Style/WhenThen:
   VersionAdded: '0.9'
 Style/WhileUntilDo:
   VersionAdded: '0.9'
+  Exclude:
+  - "/**/*.erb"
 Style/WhileUntilModifier:
   VersionAdded: '0.9'
   VersionChanged: '0.30'
+  Exclude:
+  - "/**/*.erb"
 Style/WordArray:
   VersionAdded: '0.9'
   VersionChanged: '1.19'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ gemspec
 
 group :development, :test do
   gem 'gl_lint'
-  gem 'rake', '~> 13.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rake'
+  gem 'rspec'
 end

--- a/default.yml
+++ b/default.yml
@@ -4,6 +4,7 @@ require:
   - rubocop-rspec
   - rubocop-magic_numbers
   - rubocop-erb
+  - rubocop-haml
   - rubocop-i18n
   - rubocop-rake
   - rubocop-sorbet

--- a/default.yml
+++ b/default.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-magic_numbers
-  - rubocop-haml
+  - rubocop-rspec
   - rubocop-i18n
   - rubocop-rake
   - rubocop-sorbet

--- a/default.yml
+++ b/default.yml
@@ -12,7 +12,7 @@ require:
   - ./lib/gl_rubocop/gl_cops/interactor_inherits_from_interactor_base.rb
   - ./lib/gl_rubocop/gl_cops/limit_flash_options.rb
   - ./lib/gl_rubocop/gl_cops/no_stubbing_perform_async.rb
-  - ./lib/gl_rubocop/gl_cops/prevent_erb_files.rb
+  - ./lib/gl_rubocop/gl_cops/prevent_haml_files.rb
   - ./lib/gl_rubocop/gl_cops/rails_cache.rb
   - ./lib/gl_rubocop/gl_cops/sidekiq_inherits_from_sidekiq_job.rb
   - ./lib/gl_rubocop/gl_cops/unique_identifier.rb
@@ -54,7 +54,7 @@ GLCops/NoStubbingPerformAsync:
   Include:
     - "**/*spec.rb"
 
-GLCops/PreventErbFiles:
+GLCops/PreventHamlFiles:
   Enabled: true
 
 GLCops/RailsCache:

--- a/default.yml
+++ b/default.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-magic_numbers
-  - rubocop-rspec
+  - rubocop-erb
   - rubocop-i18n
   - rubocop-rake
   - rubocop-sorbet
@@ -67,7 +67,7 @@ GLCops/SidekiqInheritsFromSidekiqJob:
 GLCops/UniqueIdentifier:
   Enabled: true
   Include:
-    - "app/components/**/*.haml"
+    - "app/components/**/*.erb"
 
 I18n/GetText:
   Enabled: false

--- a/gl_rubocop.gemspec
+++ b/gl_rubocop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.62.1'
+  spec.add_dependency 'rubocop'
   spec.add_dependency 'rubocop-erb'
   spec.add_dependency 'rubocop-i18n'
   spec.add_dependency 'rubocop-magic_numbers'

--- a/gl_rubocop.gemspec
+++ b/gl_rubocop.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop', '~> 1.62.1'
+  spec.add_dependency 'rubocop-haml', '~> 0.2.4'
   spec.add_dependency 'rubocop-erb'
   spec.add_dependency 'rubocop-i18n'
   spec.add_dependency 'rubocop-magic_numbers'

--- a/gl_rubocop.gemspec
+++ b/gl_rubocop.gemspec
@@ -2,8 +2,6 @@
 
 require_relative 'lib/gl_rubocop/version'
 
-NON_GEM_FILES = ['Gemfile', 'Gemfile.lock', 'Guardfile', 'bin/lint'].freeze
-
 Gem::Specification.new do |spec|
   spec.name = 'gl_rubocop'
   spec.version = GLRubocop::VERSION
@@ -26,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 1.62.1'
-  spec.add_dependency 'rubocop-haml', '~> 0.2.4'
   spec.add_dependency 'rubocop-erb'
+  spec.add_dependency 'rubocop-haml', '~> 0.2.4'
   spec.add_dependency 'rubocop-i18n'
   spec.add_dependency 'rubocop-magic_numbers'
   spec.add_dependency 'rubocop-performance'

--- a/gl_rubocop.gemspec
+++ b/gl_rubocop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 1.62.1'
   spec.add_dependency 'rubocop-erb'
-  spec.add_dependency 'rubocop-haml', '~> 0.2.4'
+  spec.add_dependency 'rubocop-haml'
   spec.add_dependency 'rubocop-i18n'
   spec.add_dependency 'rubocop-magic_numbers'
   spec.add_dependency 'rubocop-performance'

--- a/gl_rubocop.gemspec
+++ b/gl_rubocop.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 1.62.1'
-  spec.add_dependency 'rubocop-haml', '~> 0.2.4'
+  spec.add_dependency 'rubocop-erb'
   spec.add_dependency 'rubocop-i18n'
   spec.add_dependency 'rubocop-magic_numbers'
   spec.add_dependency 'rubocop-performance'

--- a/lib/gl_rubocop/gl_cops/prevent_haml_files.rb
+++ b/lib/gl_rubocop/gl_cops/prevent_haml_files.rb
@@ -1,11 +1,11 @@
 module GLRubocop
   module GLCops
-    class PreventErbFiles < RuboCop::Cop::Cop
-      MSG = 'File name should not end with .erb'.freeze
+    class PreventHamlFiles < RuboCop::Cop::Cop
+      MSG = 'File name should not end with .haml'.freeze
 
       def investigate(processed_source)
         file_path = processed_source.buffer.name
-        return unless File.extname(file_path) == '.erb'
+        return unless File.extname(file_path) == '.haml'
 
         range = processed_source.buffer.source_range
         add_offense(nil, location: range, message: MSG)

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.19'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/gl_rubocop/gl_cops/prevent_haml_files_spec.rb
+++ b/spec/gl_rubocop/gl_cops/prevent_haml_files_spec.rb
@@ -2,15 +2,15 @@
 
 require 'rubocop'
 require 'rubocop/rspec/support'
-require 'gl_rubocop/gl_cops/prevent_erb_files'
+require 'gl_rubocop/gl_cops/prevent_haml_files'
 
-RSpec.describe GLRubocop::GLCops::PreventErbFiles do
+RSpec.describe GLRubocop::GLCops::PreventHamlFiles do
   include RuboCop::RSpec::ExpectOffense
   let(:config) { RuboCop::Config.new }
   let(:cop) { described_class.new(config) }
   let(:commissioner) { RuboCop::Cop::Commissioner.new([cop]) }
   let(:source) do
-    Tempfile.open(['bad_file', '.erb']) do |file|
+    Tempfile.open(['bad_file', '.haml']) do |file|
       file.write('bad contents')
       file.close
       file.path
@@ -18,7 +18,7 @@ RSpec.describe GLRubocop::GLCops::PreventErbFiles do
   end
 
   describe 'investigate' do
-    it 'reports an offense if file name ends in .erb' do
+    it 'reports an offense if file name ends in .haml' do
       source_file = File.read(source)
       processed_source = RuboCop::ProcessedSource.new(source_file, RUBY_VERSION.to_f, source)
       investigation_report = commissioner.investigate(processed_source)


### PR DESCRIPTION
[DEV-11831](https://give-lively.atlassian.net/browse/DEV-11831)

Updates version to 0.3.0