### PR TITLE
bumps the version number for gl_rubocop

### DIFF
--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.2.19'.freeze
+  VERSION = '0.2.20'.freeze
 end


### PR DESCRIPTION
Bumps the repo's version number following: https://github.com/givelively/gl_rubocop/pull/25