### PR TITLE
v0.3.3 - Add ViewComponent initialize keyword args cop

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -82,7 +82,7 @@ GLCops/UniqueIdentifier:
   - app/components/**/*.erb
 GLCops/ViewComponentInitializeKeywordArgs:
   Include:
-  - app/components/**/*_component.rb
+  - app/components/**/component.rb
 Gemspec/DuplicatedAssignment:
   Severity: warning
   VersionAdded: '0.52'

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -80,6 +80,9 @@ GLCops/SidekiqInheritsFromSidekiqJob:
 GLCops/UniqueIdentifier:
   Include:
   - app/components/**/*.erb
+GLCops/ViewComponentInitializeKeywordArgs:
+  Include:
+  - app/components/**/*_component.rb
 Gemspec/DuplicatedAssignment:
   Severity: warning
   VersionAdded: '0.52'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'benchmark'
   gem 'gl_lint'
   gem 'guard'
   gem 'guard-rspec'

--- a/app/components/component.rb
+++ b/app/components/component.rb
@@ -1,0 +1,6 @@
+class ExampleComponent < ViewComponent::Base
+  def initialize(name, age)
+    @name = name
+    @age = age
+  end
+end

--- a/app/components/component.rb
+++ b/app/components/component.rb
@@ -1,6 +1,0 @@
-class ExampleComponent < ViewComponent::Base
-  def initialize(name, age)
-    @name = name
-    @age = age
-  end
-end

--- a/default.yml
+++ b/default.yml
@@ -17,6 +17,7 @@ require:
   - ./lib/gl_rubocop/gl_cops/sidekiq_inherits_from_sidekiq_job.rb
   - ./lib/gl_rubocop/gl_cops/unique_identifier.rb
   - ./lib/gl_rubocop/gl_cops/tailwind_no_contradicting_class_name.rb
+  - ./lib/gl_rubocop/gl_cops/view_component_initialize_keyword_args.rb
 
 AllCops:
   SuggestExtensions: false
@@ -74,6 +75,11 @@ GLCops/UniqueIdentifier:
   Enabled: true
   Include:
     - "app/components/**/*.erb"
+
+GLCops/ViewComponentInitializeKeywordArgs:
+  Enabled: true
+  Include:
+    - "app/components/**/*_component.rb"
 
 I18n/GetText:
   Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -79,7 +79,7 @@ GLCops/UniqueIdentifier:
 GLCops/ViewComponentInitializeKeywordArgs:
   Enabled: true
   Include:
-    - "app/components/**/*_component.rb"
+    - "app/components/**/component.rb"
 
 I18n/GetText:
   Enabled: false

--- a/lib/gl_rubocop/gl_cops/view_component_initialize_keyword_args.rb
+++ b/lib/gl_rubocop/gl_cops/view_component_initialize_keyword_args.rb
@@ -12,7 +12,7 @@ module GLRubocop
     #   def initialize(name, age)
     #   def initialize(name, age:)
     class ViewComponentInitializeKeywordArgs < RuboCop::Cop::Cop
-      MSG = 'ViewComponent initialize methods must use keyword arguments only.'
+      MSG = 'ViewComponent initialize methods must use keyword arguments only.'.freeze
 
       def on_def(node)
         return unless node.method_name == :initialize

--- a/lib/gl_rubocop/gl_cops/view_component_initialize_keyword_args.rb
+++ b/lib/gl_rubocop/gl_cops/view_component_initialize_keyword_args.rb
@@ -1,0 +1,30 @@
+# rubocop:disable I18n/RailsI18n/DecorateString
+module GLRubocop
+  module GLCops
+    # This cop ensures that ViewComponent initialize methods use keyword arguments only.
+    #
+    # Good:
+    #   def initialize(name:, age:)
+    #   def initialize(name:, age: 18)
+    #   def initialize(**options)
+    #
+    # Bad:
+    #   def initialize(name, age)
+    #   def initialize(name, age:)
+    class ViewComponentInitializeKeywordArgs < RuboCop::Cop::Cop
+      MSG = 'ViewComponent initialize methods must use keyword arguments only.'
+
+      def on_def(node)
+        return unless node.method_name == :initialize
+        return if node.arguments.empty?
+
+        has_positional_args = node.arguments.any? do |arg|
+          arg.arg_type? || arg.optarg_type? || arg.restarg_type?
+        end
+
+        add_offense(node, message: MSG) if has_positional_args
+      end
+    end
+  end
+end
+# rubocop:enable I18n/RailsI18n/DecorateString

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.3'.freeze
 end

--- a/spec/gl_rubocop/gl_cops/view_component_initialize_keyword_args_spec.rb
+++ b/spec/gl_rubocop/gl_cops/view_component_initialize_keyword_args_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'gl_rubocop/gl_cops/view_component_initialize_keyword_args'
+
+RSpec.describe GLRubocop::GLCops::ViewComponentInitializeKeywordArgs do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+  let(:commissioner) { RuboCop::Cop::Commissioner.new([cop]) }
+  let(:expected_message) do
+    'GLCops/ViewComponentInitializeKeywordArgs: ViewComponent initialize methods must use keyword arguments only.'
+  end
+
+  it 'registers an offense when initialize has positional arguments' do
+    source = <<~RUBY
+      def initialize(name, age)
+        @name = name
+        @age = age
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(1)
+    expect(report.offenses.first.message).to eq(expected_message)
+  end
+
+  it 'registers an offense when initialize has mixed positional and keyword arguments' do
+    source = <<~RUBY
+      def initialize(name, age:)
+        @name = name
+        @age = age
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(1)
+    expect(report.offenses.first.message).to eq(expected_message)
+  end
+
+  it 'registers an offense when initialize has optional positional arguments' do
+    source = <<~RUBY
+      def initialize(name = "default")
+        @name = name
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(1)
+    expect(report.offenses.first.message).to eq(expected_message)
+  end
+
+  it 'registers an offense when initialize has splat arguments' do
+    source = <<~RUBY
+      def initialize(*args)
+        @args = args
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(1)
+    expect(report.offenses.first.message).to eq(expected_message)
+  end
+
+  it 'does not register an offense when initialize has only keyword arguments' do
+    source = <<~RUBY
+      def initialize(name:, age:)
+        @name = name
+        @age = age
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(0)
+  end
+
+  it 'does not register an offense when initialize has keyword arguments with defaults' do
+    source = <<~RUBY
+      def initialize(name:, age: 18)
+        @name = name
+        @age = age
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(0)
+  end
+
+  it 'does not register an offense when initialize has double splat arguments' do
+    source = <<~RUBY
+      def initialize(**options)
+        @options = options
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(0)
+  end
+
+  it 'does not register an offense when initialize has no arguments' do
+    source = <<~RUBY
+      def initialize
+        @value = "default"
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(0)
+  end
+
+  it 'does not register an offense for non-initialize methods' do
+    source = <<~RUBY
+      def some_method(name, age)
+        @name = name
+        @age = age
+      end
+    RUBY
+
+    processed_source = parse_source(source)
+    report = commissioner.investigate(processed_source)
+
+    expect(report.offenses.size).to eq(0)
+  end
+end


### PR DESCRIPTION
- Requires all ViewComponent initialize methods to use keyword arguments only
- Applies to files in app/components/ with *_component.rb filenames
- Includes comprehensive test coverage

Done using copilot CLI, prompting with:

> Add GLRubocop that requiring all arguments to View Component initialize (def new) be keyword args

and then when asked if it could run `$ grep -r "ViewComponent" . --include="*.rb" 2>/dev/null | head -20`, added:

> This should apply this cop to any file that is in app/components/ which has a filename component.rb