### PR TITLE
DEV-12047: add new cop to validate data-test-id usage

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -80,6 +80,11 @@ GLCops/SidekiqInheritsFromSidekiqJob:
 GLCops/UniqueIdentifier:
   Include:
   - app/components/**/*.erb
+GLCops/ValidDataTestId:
+  Include:
+  - "**/*.erb"
+  - "**/*.haml"
+  - "**/*.rb"
 GLCops/ViewComponentInitializeKeywordArgs:
   Include:
   - app/components/**/component.rb

--- a/default.yml
+++ b/default.yml
@@ -17,6 +17,7 @@ require:
   - ./lib/gl_rubocop/gl_cops/sidekiq_inherits_from_sidekiq_job.rb
   - ./lib/gl_rubocop/gl_cops/unique_identifier.rb
   - ./lib/gl_rubocop/gl_cops/tailwind_no_contradicting_class_name.rb
+  - ./lib/gl_rubocop/gl_cops/valid_data_test_id.rb
   - ./lib/gl_rubocop/gl_cops/view_component_initialize_keyword_args.rb
 
 AllCops:
@@ -75,6 +76,13 @@ GLCops/UniqueIdentifier:
   Enabled: true
   Include:
     - "app/components/**/*.erb"
+
+GLCops/ValidDataTestId:
+  Enabled: true
+  Include:
+    - "**/*.erb"
+    - "**/*.haml"
+    - "**/*.rb"
 
 GLCops/ViewComponentInitializeKeywordArgs:
   Enabled: true

--- a/lib/gl_rubocop/gl_cops/valid_data_test_id.rb
+++ b/lib/gl_rubocop/gl_cops/valid_data_test_id.rb
@@ -12,25 +12,9 @@ module GLRubocop
       MSG = 'Use data-test-id instead of %<invalid>s'
 
       # Invalid variations of data-test-id
-      INVALID_PATTERNS = [
-        # HTML-style: data-testid="value"
-        /\bdata-testid\s*=/i,
-        /\bdata-testId\s*=/,
-        /\bdata_test_id\s*=/,
-        /\bdataTestId\s*=/,
-        # HAML/Ruby hash-style with double quotes: "data-testid": "value"
-        /"data-testid"\s*:/i,
-        /"data-testId"\s*:/,
-        /"dataTestId"\s*:/,
-        # HAML/Ruby hash-style with single quotes: 'data-testid': "value"
-        /'data-testid'\s*:/i,
-        /'data-testId'\s*:/,
-        /'dataTestId'\s*:/,
-        # Ruby hash-style without quotes: data_testid: "value"
-        /\bdata_testid\s*:/i,
-        /\bdata_test_id\s*:/,
-        /\bdataTestId\s*:/
-      ].freeze
+      # Matches: data-testid, data_test_id, datatestid, dataTestId, etc.
+      # Does NOT match: data-test-id (the valid format)
+      INVALID_PATTERN = /\bdata(?!-test-id\b)[-_]?test[-_]?id\b/i
 
       def investigate(processed_source)
         return unless haml_file? || erb_file?
@@ -50,33 +34,27 @@ module GLRubocop
       private
 
       def check_file_content(content, processed_source)
-        INVALID_PATTERNS.each do |pattern|
-          next unless content.match?(pattern)
+        return unless content.match?(INVALID_PATTERN)
 
-          match = content.match(pattern)
-          invalid_attr = match[0].split(/[=:]/).first.gsub(/["']/, '')
-          range = processed_source.buffer.source_range
-          add_offense(
-            nil,
-            location: range,
-            message: format(MSG, invalid: invalid_attr)
-          )
-          break
-        end
+        match = content.match(INVALID_PATTERN)
+        invalid_attr = match[0].split(/[=:]/).first.gsub(/["']/, '')
+        range = processed_source.buffer.source_range
+        add_offense(
+          nil,
+          location: range,
+          message: format(MSG, invalid: invalid_attr)
+        )
       end
 
       def check_string_content(content, node)
-        INVALID_PATTERNS.each do |pattern|
-          next unless content.match?(pattern)
+        return unless content.match?(INVALID_PATTERN)
 
-          match = content.match(pattern)
-          invalid_attr = match[0].split(/[=:]/).first.gsub(/["']/, '')
-          add_offense(
-            node,
-            message: format(MSG, invalid: invalid_attr)
-          )
-          break
-        end
+        match = content.match(INVALID_PATTERN)
+        invalid_attr = match[0].split(/[=:]/).first.gsub(/["']/, '')
+        add_offense(
+          node,
+          message: format(MSG, invalid: invalid_attr)
+        )
       end
     end
   end

--- a/lib/gl_rubocop/gl_cops/valid_data_test_id.rb
+++ b/lib/gl_rubocop/gl_cops/valid_data_test_id.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative '../helpers/haml_content_helper'
+require_relative '../helpers/erb_content_helper'
+
+module GLRubocop
+  module GLCops
+    class ValidDataTestId < RuboCop::Cop::Cop
+      include GLRubocop::HamlContentHelper
+      include GLRubocop::ErbContentHelper
+
+      MSG = 'Use data-test-id instead of %<invalid>s'
+
+      # Invalid variations of data-test-id
+      INVALID_PATTERNS = [
+        # HTML-style: data-testid="value"
+        /\bdata-testid\s*=/i,
+        /\bdata-testId\s*=/,
+        /\bdata_test_id\s*=/,
+        /\bdataTestId\s*=/,
+        # HAML/Ruby hash-style: "data-testid": "value" or data_testid: "value"
+        /"data-testid"\s*:/i,
+        /"data-testId"\s*:/,
+        /"dataTestId"\s*:/,
+        /\bdata_testid\s*:/i,
+        /\bdata_test_id\s*:/,
+        /\bdataTestId\s*:/
+      ].freeze
+
+      def on_send(node)
+        return unless haml_file? || erb_file?
+
+        content = haml_file? ? read_haml_file : read_erb_file
+        return unless content
+
+        check_content(content, node)
+      end
+
+      def on_str(node)
+        return unless node.str_type?
+
+        check_string_content(node.value, node)
+      end
+
+      private
+
+      def check_content(content, node)
+        INVALID_PATTERNS.each do |pattern|
+          next unless content.match?(pattern)
+
+          match = content.match(pattern)
+          invalid_attr = match[0].split(/[=:]/).first.gsub(/["']/, '')
+          add_offense(
+            node,
+            message: format(MSG, invalid: invalid_attr)
+          )
+          break
+        end
+      end
+
+      def check_string_content(content, node)
+        INVALID_PATTERNS.each do |pattern|
+          next unless content.match?(pattern)
+
+          match = content.match(pattern)
+          invalid_attr = match[0].split(/[=:]/).first.gsub(/["']/, '')
+          add_offense(
+            node,
+            message: format(MSG, invalid: invalid_attr)
+          )
+          break
+        end
+      end
+    end
+  end
+end

--- a/lib/gl_rubocop/gl_cops/valid_data_test_id.rb
+++ b/lib/gl_rubocop/gl_cops/valid_data_test_id.rb
@@ -18,22 +18,27 @@ module GLRubocop
         /\bdata-testId\s*=/,
         /\bdata_test_id\s*=/,
         /\bdataTestId\s*=/,
-        # HAML/Ruby hash-style: "data-testid": "value" or data_testid: "value"
+        # HAML/Ruby hash-style with double quotes: "data-testid": "value"
         /"data-testid"\s*:/i,
         /"data-testId"\s*:/,
         /"dataTestId"\s*:/,
+        # HAML/Ruby hash-style with single quotes: 'data-testid': "value"
+        /'data-testid'\s*:/i,
+        /'data-testId'\s*:/,
+        /'dataTestId'\s*:/,
+        # Ruby hash-style without quotes: data_testid: "value"
         /\bdata_testid\s*:/i,
         /\bdata_test_id\s*:/,
         /\bdataTestId\s*:/
       ].freeze
 
-      def on_send(node)
+      def investigate(processed_source)
         return unless haml_file? || erb_file?
 
         content = haml_file? ? read_haml_file : read_erb_file
         return unless content
 
-        check_content(content, node)
+        check_file_content(content, processed_source)
       end
 
       def on_str(node)
@@ -44,14 +49,16 @@ module GLRubocop
 
       private
 
-      def check_content(content, node)
+      def check_file_content(content, processed_source)
         INVALID_PATTERNS.each do |pattern|
           next unless content.match?(pattern)
 
           match = content.match(pattern)
           invalid_attr = match[0].split(/[=:]/).first.gsub(/["']/, '')
+          range = processed_source.buffer.source_range
           add_offense(
-            node,
+            nil,
+            location: range,
             message: format(MSG, invalid: invalid_attr)
           )
           break

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/gl_rubocop/gl_cops/unique_identifier_spec.rb
+++ b/spec/gl_rubocop/gl_cops/unique_identifier_spec.rb
@@ -83,11 +83,13 @@ RSpec.describe GLRubocop::GLCops::UniqueIdentifier do
   end
 
   context 'when render method is used with invalid data-test-id formats' do
+    # rubocop:disable GLCops/ValidDataTestId, Lint/RedundantCopDisableDirective
     invalid_templates = [
       '<div data-testId="unique-id">Some content</div>',
       '<div data-testid="unique-id">Some content</div>',
       '<div data-test_id="unique-id">Some content</div>'
     ]
+    # rubocop:enable GLCops/ValidDataTestId, Lint/RedundantCopDisableDirective
 
     invalid_templates.each do |template|
       context "when template content is #{template}" do

--- a/spec/gl_rubocop/gl_cops/valid_data_test_id_spec.rb
+++ b/spec/gl_rubocop/gl_cops/valid_data_test_id_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'gl_rubocop/gl_cops/valid_data_test_id'
+
+RSpec.describe GLRubocop::GLCops::ValidDataTestId do
+  include RuboCop::RSpec::ExpectOffense
+
+  subject(:cop) { described_class.new }
+
+  let!(:processed_source) { parse_source(source) }
+  let(:source) { 'render "component"' }
+
+  before do
+    allow_any_instance_of(described_class).to receive(:processed_source)
+      .and_return(processed_source)
+    allow(processed_source).to receive(:file_path).and_return(file_path)
+    allow(File).to receive(:exist?).with(file_path).and_return(true)
+    allow(File).to receive(:read).with(file_path).and_return(template_content)
+  end
+
+  context 'when in an ERB file' do
+    let(:file_path) { '/path/to/component.html.erb' }
+
+    context 'with valid data-test-id format' do
+      let(:template_content) do
+        <<~ERB
+          <div data-test-id="unique-id">Some content</div>
+        ERB
+      end
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          render "component"
+        RUBY
+      end
+    end
+
+    context 'with invalid data-testid format' do
+      let(:template_content) do
+        <<~ERB
+          <div data-testid="unique-id">Some content</div>
+        ERB
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data-testid
+        RUBY
+      end
+    end
+
+    context 'with invalid data-testId format (camelCase)' do
+      let(:template_content) do
+        <<~ERB
+          <div data-testId="unique-id">Some content</div>
+        ERB
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data-testId
+        RUBY
+      end
+    end
+
+    context 'with invalid data_test_id format (snake_case)' do
+      let(:template_content) do
+        <<~ERB
+          <div data_test_id="unique-id">Some content</div>
+        ERB
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data_test_id
+        RUBY
+      end
+    end
+
+    context 'with invalid dataTestId format (camelCase no dash)' do
+      let(:template_content) do
+        <<~ERB
+          <div dataTestId="unique-id">Some content</div>
+        ERB
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of dataTestId
+        RUBY
+      end
+    end
+
+    context 'with no test id attribute' do
+      let(:template_content) do
+        <<~ERB
+          <div class="container">Some content</div>
+        ERB
+      end
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          render "component"
+        RUBY
+      end
+    end
+  end
+
+  context 'when in a HAML file' do
+    let(:file_path) { '/path/to/component.html.haml' }
+
+    context 'with valid data-test-id format' do
+      let(:template_content) do
+        <<~HAML
+          %div{ "data-test-id": "unique-id" }
+            Some content
+        HAML
+      end
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          render "component"
+        RUBY
+      end
+    end
+
+    context 'with invalid data-testid format' do
+      let(:template_content) do
+        <<~HAML
+          %div{ "data-testid": "unique-id" }
+            Some content
+        HAML
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data-testid
+        RUBY
+      end
+    end
+
+    context 'with invalid data_test_id format in HAML hash' do
+      let(:template_content) do
+        <<~HAML
+          %div{ data_test_id: "unique-id" }
+            Some content
+        HAML
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data_test_id
+        RUBY
+      end
+    end
+  end
+
+  context 'when checking string literals in Ruby code' do
+    let(:file_path) { '/path/to/file.rb' }
+    let(:template_content) { '' }
+
+    it 'does not register an offense for valid data-test-id in string' do
+      expect_no_offenses(<<~RUBY)
+        html = '<div data-test-id="unique-id">Content</div>'
+      RUBY
+    end
+
+    it 'registers an offense for invalid data-testid in string' do
+      expect_offense(<<~RUBY)
+        html = '<div data-testid="unique-id">Content</div>'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data-testid
+      RUBY
+    end
+  end
+end

--- a/spec/gl_rubocop/gl_cops/valid_data_test_id_spec.rb
+++ b/spec/gl_rubocop/gl_cops/valid_data_test_id_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe GLRubocop::GLCops::ValidDataTestId do
     allow(File).to receive(:read).with(file_path).and_return(template_content)
   end
 
+  # rubocop:disable GLCops/ValidDataTestId, Lint/RedundantCopDisableDirective
   context 'when in an ERB file' do
     let(:file_path) { '/path/to/component.html.erb' }
 
@@ -180,4 +181,5 @@ RSpec.describe GLRubocop::GLCops::ValidDataTestId do
       RUBY
     end
   end
+  # rubocop:enable GLCops/ValidDataTestId, Lint/RedundantCopDisableDirective
 end

--- a/spec/gl_rubocop/gl_cops/valid_data_test_id_spec.rb
+++ b/spec/gl_rubocop/gl_cops/valid_data_test_id_spec.rb
@@ -162,6 +162,54 @@ RSpec.describe GLRubocop::GLCops::ValidDataTestId do
         RUBY
       end
     end
+
+    context 'with invalid data-testId format in HAML hash with single quotes' do
+      let(:template_content) do
+        <<~HAML
+          %div{ 'data-testId': "unique-id" }
+            Some content
+        HAML
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data-testId
+        RUBY
+      end
+    end
+
+    context 'with invalid data-testid format in HAML hash with single quotes' do
+      let(:template_content) do
+        <<~HAML
+          %div{ 'data-testid': "unique-id" }
+            Some content
+        HAML
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of data-testid
+        RUBY
+      end
+    end
+
+    context 'with invalid dataTestId format in HAML hash with single quotes' do
+      let(:template_content) do
+        <<~HAML
+          %div{ 'dataTestId': "unique-id" }
+            Some content
+        HAML
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          render "component"
+          ^^^^^^^^^^^^^^^^^^ GLCops/ValidDataTestId: Use data-test-id instead of dataTestId
+        RUBY
+      end
+    end
   end
 
   context 'when checking string literals in Ruby code' do


### PR DESCRIPTION
Added new `valid_data_test_id` cop that enforces the correct data-test-id format across ERB, HAML, and Ruby files.