### PR TITLE
Add NoStubbingEnv cop

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle exec *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(bundle exec *)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ Gemfile.lock
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
 .rspec_status
+
+# Ignore LLM settings
+.claude/settings.local.json
+.aider*

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -71,6 +71,9 @@ GLCops/InteractorInheritsFromInteractorBase:
   Include:
   - app/interactors/**/*
 GLCops/LimitFlashOptions: {}
+GLCops/NoStubbingEnv:
+  Include:
+  - "**/*spec.rb"
 GLCops/NoStubbingPerformAsync:
   Include:
   - "**/*spec.rb"

--- a/default.yml
+++ b/default.yml
@@ -12,6 +12,7 @@ require:
   - ./lib/gl_rubocop/gl_cops/consolidate_request_system_specs.rb
   - ./lib/gl_rubocop/gl_cops/interactor_inherits_from_interactor_base.rb
   - ./lib/gl_rubocop/gl_cops/limit_flash_options.rb
+  - ./lib/gl_rubocop/gl_cops/no_stubbing_env.rb
   - ./lib/gl_rubocop/gl_cops/no_stubbing_perform_async.rb
   - ./lib/gl_rubocop/gl_cops/prevent_haml_files.rb
   - ./lib/gl_rubocop/gl_cops/rails_cache.rb
@@ -61,6 +62,11 @@ GLCops/InteractorInheritsFromInteractorBase:
 
 GLCops/LimitFlashOptions:
   Enabled: true
+
+GLCops/NoStubbingEnv:
+  Enabled: true
+  Include:
+    - "**/*spec.rb"
 
 GLCops/NoStubbingPerformAsync:
   Enabled: true

--- a/lib/gl_rubocop/gl_cops/no_stubbing_env.rb
+++ b/lib/gl_rubocop/gl_cops/no_stubbing_env.rb
@@ -1,0 +1,42 @@
+module GLRubocop
+  module GLCops
+    # This cop ensures that you don't stub ENV with `allow`/`expect` + `receive`.
+    #
+    # Stubbing ENV this way (even with `and_call_original`) only stubs the env vars the
+    # spec explicitly knows about. Any var that is read but not stubbed - for example a
+    # var that is present on CI but not locally, or vice versa - behaves inconsistently
+    # and causes flaky failures.
+    #
+    # Instead, replace ENV wholesale with `stub_const`, building the hash from the real
+    # ENV so unrelated vars keep working everywhere:
+    #
+    # Good:
+    #   stub_const('ENV', ENV.to_hash.except('VAR_TO_UNSET').merge('VAR_TO_SET' => 'value'))
+    #
+    # Bad:
+    #   allow(ENV).to receive(:[]).and_call_original
+    #   allow(ENV).to receive(:[]).with('VAR_TO_SET').and_return('value')
+    #   expect(ENV).to receive(:fetch)
+    class NoStubbingEnv < RuboCop::Cop::Base
+      MSG = "Don't stub ENV with allow/expect + receive. Use " \
+            "stub_const('ENV', ENV.to_hash.except('VAR_TO_UNSET')." \
+            "merge('VAR_TO_SET' => 'value')) instead, so unrelated ENV vars " \
+            '(e.g. on CI) keep working.'.freeze
+
+      # Match `allow(ENV).to receive(...)` / `expect(ENV).not_to receive(...)`, including
+      # chained forms like `.and_call_original`, `.and_return(...)`, `.with(...)`.
+      def_node_matcher :stubbing_env?, <<~PATTERN
+        (send
+          (send nil? {:allow :expect} (const {nil? cbase} :ENV))
+          {:to :not_to :to_not}
+          `(send nil? :receive ...))
+      PATTERN
+
+      def on_send(node)
+        return unless stubbing_env?(node)
+
+        add_offense(node)
+      end
+    end
+  end
+end

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.5.2'.freeze
+  VERSION = '0.6.0'.freeze
 end

--- a/lib/gl_rubocop/version.rb
+++ b/lib/gl_rubocop/version.rb
@@ -1,3 +1,3 @@
 module GLRubocop
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.5.3'.freeze
 end

--- a/spec/gl_rubocop/gl_cops/no_stubbing_env_spec.rb
+++ b/spec/gl_rubocop/gl_cops/no_stubbing_env_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'gl_rubocop/gl_cops/no_stubbing_env'
+
+RSpec.describe GLRubocop::GLCops::NoStubbingEnv do
+  include RuboCop::RSpec::ExpectOffense
+
+  subject(:cop) { described_class.new }
+
+  let(:message) do
+    "GLCops/NoStubbingEnv: Don't stub ENV with allow/expect + receive. Use " \
+      "stub_const('ENV', ENV.to_hash.except('VAR_TO_UNSET').merge('VAR_TO_SET' => 'value')) " \
+      'instead, so unrelated ENV vars (e.g. on CI) keep working.'
+  end
+
+  it 'registers an offense for allow(ENV).to receive(:[]).and_call_original' do
+    expect_offense(<<~RUBY)
+      allow(ENV).to receive(:[]).and_call_original
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense for allow(ENV).to receive(:[]).with(...).and_return(...)' do
+    expect_offense(<<~RUBY)
+      allow(ENV).to receive(:[]).with('FOO').and_return('bar')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense for allow(ENV).to receive(:fetch)' do
+    expect_offense(<<~RUBY)
+      allow(ENV).to receive(:fetch)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense for expect(ENV).to receive(:[])' do
+    expect_offense(<<~RUBY)
+      expect(ENV).to receive(:[])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense for expect(ENV).not_to receive(:[])' do
+    expect_offense(<<~RUBY)
+      expect(ENV).not_to receive(:[])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense for a top-level ::ENV constant' do
+    expect_offense(<<~RUBY)
+      allow(::ENV).to receive(:[]).and_call_original
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'does not register an offense for stub_const on ENV' do
+    expect_no_offenses(<<~RUBY)
+      stub_const('ENV', ENV.to_hash.except('VAR_TO_UNSET').merge('VAR_TO_SET' => 'value'))
+    RUBY
+  end
+
+  it 'does not register an offense for plain expectations on ENV' do
+    expect_no_offenses(<<~RUBY)
+      expect(ENV['FOO']).to eq('bar')
+    RUBY
+  end
+
+  it 'does not register an offense for stubbing another constant' do
+    expect_no_offenses(<<~RUBY)
+      allow(SomeClass).to receive(:[]).and_call_original
+    RUBY
+  end
+end


### PR DESCRIPTION
Replace `allow(ENV).to receive(:[]).and_call_original` with `stub_const('ENV', ENV.to_hash.merge/except(...))` in specs so the test environment is deterministic regardless of which env vars happen to be set on the runner.